### PR TITLE
Fixing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: python
 matrix:
   include:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='aw-qt',
       packages=['aw_qt'],
       install_requires=[
           'aw-core>=0.1',
-          'PyQt5>=5.7'
+          'PyQt5>=5.8'
       ],
       dependency_links=[
           'https://github.com/ActivityWatch/aw-core/tarball/master#egg=aw-core-0.1.0'


### PR DESCRIPTION
Had some issues with PyQt 5.9 requiring Glibc 2.17, fixed by using trusty on Travis instead.