### PR TITLE
Autodetect modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,13 @@ before_install:
  - python -V
  - pip -V
  - pip3 install --upgrade pip
- - pip3 install pyinstaller
+ - pip3 install mypy pyinstaller
 
 install:
  - make build
 
 script:
+ - make typecheck
  - make test
  - make test-integration
  - make package

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -5,7 +5,7 @@ from time import sleep
 import logging
 import subprocess
 import shutil
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 import aw_core
 
@@ -25,6 +25,7 @@ def _locate_bundled_executable(name: str) -> Optional[str]:
         if os.path.isfile(exec_path):
             # logger.debug("Found executable for {} in: {}".format(name, exec_path))
             return exec_path
+    return None
 
 
 def _is_system_module(name) -> bool:

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -69,10 +69,11 @@ def _discover_modules_system() -> List[str]:
     search_paths = os.environ["PATH"].split(":")
     modules = []
     for path in search_paths:
-        files = os.listdir(path)
-        for filename in files:
-            if "aw-" in filename:
-                modules.append(filename)
+        if os.path.isdir(path):
+            files = os.listdir(path)
+            for filename in files:
+                if "aw-" in filename:
+                    modules.append(filename)
 
     logger.info("Found system modules: {}".format(set(modules)))
     return modules

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -81,7 +81,7 @@ def _discover_modules_system() -> List[str]:
 class Module:
     def __init__(self, name: str, testing: bool = False) -> None:
         self.name = name
-        self.started = False
+        self.started = False  # Should be True if module is supposed to be running, else False
         self.testing = testing
         self._process = None  # type: Optional[subprocess.Popen]
         self._last_process = None  # type: Optional[subprocess.Popen]
@@ -105,9 +105,11 @@ class Module:
 
             # There is a very good reason stdout and stderr is not PIPE here
             # See: https://github.com/ActivityWatch/aw-server/issues/27
-            self._process = subprocess.Popen(exec_cmd, universal_newlines=True)
+            try:
+                self._process = subprocess.Popen(exec_cmd, universal_newlines=True)
+            except OSError as e:
+                logger.error("Couldn't start module with command {} ({})".format(exec_cmd, e))
 
-            # Should be True if module is supposed to be running, else False
             self.started = True
 
     def stop(self) -> None:

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -84,6 +84,7 @@ class Module:
         self.name = name
         self.started = False  # Should be True if module is supposed to be running, else False
         self.testing = testing
+        self.location = "system" if _is_system_module(name) else "bundled"
         self._process = None  # type: Optional[subprocess.Popen]
         self._last_process = None  # type: Optional[subprocess.Popen]
 
@@ -168,12 +169,7 @@ class Manager:
 
     def discover_modules(self):
         # These should always be bundled with aw-qt
-        found_modules = {
-            "aw-server",
-            "aw-watcher-afk",
-            "aw-watcher-window"
-        }
-        found_modules |= set(_discover_modules_bundled())
+        found_modules = set(_discover_modules_bundled())
         found_modules |= set(_discover_modules_system())
         found_modules ^= {"aw-qt"}  # Exclude self
 

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -56,7 +56,8 @@ def _discover_modules_bundled() -> List[str]:
         matches = glob(os.path.join(path, "aw-*"))
         for match in matches:
             if os.path.isfile(match) and os.access(match, os.X_OK):
-                modules.append(match)
+                name = os.path.basename(match)
+                modules.append(name)
             else:
                 logger.warning("Found matching file but was not executable: {}".format(path))
 
@@ -171,6 +172,7 @@ class Manager:
         }
         found_modules |= set(_discover_modules_bundled())
         found_modules |= set(_discover_modules_system())
+        found_modules ^= {"aw-qt"}  # Exclude self
 
         for m_name in found_modules:
             if m_name not in self.modules:

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -4,6 +4,7 @@ import signal
 import webbrowser
 import os
 import subprocess
+from collections import defaultdict
 
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QApplication, QSystemTrayIcon, QMessageBox, QMenu, QWidget, QPushButton
@@ -93,12 +94,18 @@ class TrayIcon(QSystemTrayIcon):
             box.show()
 
         def rebuild_modules_menu():
-            for module in modulesMenu.actions():
-                name = module.text()
-                alive = self.manager.modules[name].is_alive()
-                module.setChecked(alive)
-                # print(module.text(), alive)
+            for action in modulesMenu.actions():
+                if action.isEnabled():
+                    name = action.module.name
+                    alive = self.manager.modules[name].is_alive()
+                    action.setChecked(alive)
+                    # print(module.text(), alive)
 
+            # TODO: Do it in a better way, singleShot isn't pretty...
+            QtCore.QTimer.singleShot(2000, rebuild_modules_menu)
+        QtCore.QTimer.singleShot(2000, rebuild_modules_menu)
+
+        def check_module_status():
             unexpected_exits = self.manager.get_unexpected_stops()
             if unexpected_exits:
                 for module in unexpected_exits:
@@ -107,22 +114,34 @@ class TrayIcon(QSystemTrayIcon):
 
             # TODO: Do it in a better way, singleShot isn't pretty...
             QtCore.QTimer.singleShot(2000, rebuild_modules_menu)
-
-        QtCore.QTimer.singleShot(2000, rebuild_modules_menu)
+        QtCore.QTimer.singleShot(2000, check_module_status)
 
     def _build_modulemenu(self, moduleMenu):
         moduleMenu.clear()
 
         def add_module_menuitem(module):
-            ac = moduleMenu.addAction(module.name, lambda: module.toggle())
+            title = module.name
+            ac = moduleMenu.addAction(title, lambda: module.toggle())
+            # Kind of nasty, but a quick way to affiliate the module to the menu action for when it needs updating
+            ac.module = module
             ac.setCheckable(True)
             ac.setChecked(module.is_alive())
 
-        add_module_menuitem(self.manager.modules["aw-server"])
+        modules_by_location = defaultdict(lambda: list())
+        for module in sorted(self.manager.modules.values(), key=lambda m: m.name):
+            modules_by_location[module.location].append(module)
 
-        for module_name in sorted(self.manager.modules.keys()):
-            if module_name != "aw-server":
-                add_module_menuitem(self.manager.modules[module_name])
+        for location, modules in sorted(modules_by_location.items(), key=lambda kv: kv[0]):
+            header = moduleMenu.addAction(location)
+            header.setEnabled(False)
+
+            # Always show aw-server first
+            if "aw-server" in (m.name for m in modules):
+                add_module_menuitem(self.manager.modules["aw-server"])
+
+            for module in sorted(modules, key=lambda m: m.name):
+                if module.name != "aw-server":
+                    add_module_menuitem(self.manager.modules[module.name])
 
 
 def exit_dialog():

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -38,7 +38,7 @@ def open_dir(d):
 
 
 class TrayIcon(QSystemTrayIcon):
-    def __init__(self, manager: Manager, icon, parent=None, testing=False):
+    def __init__(self, manager: Manager, icon, parent=None, testing=False) -> None:
         QSystemTrayIcon.__init__(self, icon, parent)
         self.setToolTip("ActivityWatch" + (" (testing)" if testing else ""))
 
@@ -196,7 +196,3 @@ def run(manager, testing=False):
 
     # Run the application, blocks until quit
     return app.exec_()
-
-
-if __name__ == "__main__":
-    run()


### PR DESCRIPTION
This is a nice one.

 - Detects modules in the users PATH (executables must contain `"aw-"`)
 - Detects modules bundled with aw-qt (in the same directory)

This makes it a lot easier to run manage whichever module/watcher you want with aw-qt. 