### PR TITLE
Only disable console on Windows

### DIFF
--- a/aw-qt.spec
+++ b/aw-qt.spec
@@ -45,7 +45,7 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           icon=icon,
-          console=False)
+          console=False if platform.system() == "Windows" else True)
 coll = COLLECT(exe,
                a.binaries,
                a.zipfiles,


### PR DESCRIPTION
This needs to be tested properly before merging since it turns out that `console=False` has some implications that might break stuff unexpectedly.

Also, having the console show up is really useful when debugging (or just when users come across unexpected behaviors, which still happens from time to time). The preferable thing would be to give the executable a parameter to hide/show the console. (See https://github.com/pyinstaller/pyinstaller/issues/2117 and https://github.com/pyinstaller/pyinstaller/issues/1339#issuecomment-122909830)