### PR TITLE
[macOS] removes python-rocket from dock if pyobjc is installed

### DIFF
--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -56,11 +56,14 @@ class Module:
 
         # Don't display a console window on Windows
         # See: https://github.com/ActivityWatch/activitywatch/issues/212
+        startupinfo = None
         if platform.system() == "Windows":
             startupinfo = subprocess.STARTUPINFO()  # type: ignore
             startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW  # type: ignore
-        else:
-            startupinfo = None
+        elif platform.system() == "Darwin":
+            logger.info("Macos: Disable dock icon")
+            import AppKit
+            AppKit.NSBundle.mainBundle().infoDictionary()["LSBackgroundOnly"] = "1"
 
         # There is a very good reason stdout and stderr is not PIPE here
         # See: https://github.com/ActivityWatch/aw-server/issues/27

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,10 @@ setup(name='aw-qt',
       url='https://github.com/ActivityWatch/aw-trayicon',
       packages=['aw_qt'],
       install_requires=[
-          'aw-core>=0.1',
-          'PyQt5<5.11'
-      ],
+        'aw-core>=0.1',
+        'PyQt5<5.11',
+        'pyobjc;platform_system=="Darwin"'
+        ],
       dependency_links=[
           'https://github.com/ActivityWatch/aw-core/tarball/master#egg=aw-core-0.1.0'
       ],


### PR DESCRIPTION
Tries to disable the dock icon, when aw-qt is launched on macOS.

However I only found a solution with `AppKit` (`python3 -m pip install pyobjc`), which is a macos-only package. Instead of including it in a setup script, I just catch the import error. Not the nicest solution, but it works. When writing the documentation about auto starting on macOS we should add this information.

