### PR TITLE
Store available and autostart modules lists as configuration. See #47

### DIFF
--- a/aw_qt/config.py
+++ b/aw_qt/config.py
@@ -1,0 +1,36 @@
+from configparser import ConfigParser
+
+from aw_core.config import load_config
+import json
+
+default_settings = {
+    "possible_modules": json.dumps(["aw-server",
+                                    "aw-watcher-afk",
+                                    "aw-watcher-window", ]),
+    "autostart_modules": json.dumps(["aw-server",
+                                     "aw-watcher-afk",
+                                     "aw-watcher-window", ]),
+}
+default_testing_settings = {
+    "possible_modules": json.dumps(["aw-server",
+                                    "aw-watcher-afk",
+                                    "aw-watcher-window", ]),
+    "autostart_modules": json.dumps(["aw-server",
+                                     "aw-watcher-afk",
+                                     "aw-watcher-window", ]),
+}
+
+default_config = ConfigParser()
+default_config['aw-qt'] = default_settings
+default_config['aw-qt-testing'] = default_testing_settings
+qt_config = load_config("aw-qt", default_config)
+
+
+class QTSettings:
+    def __init__(self, testing: bool):
+        config_section = qt_config["aw-qt" if not testing else "aw-qt-testing"]
+
+        # TODO: Resolved available modules automatically.
+        # TODO: Filter away all modules not available on system
+        self.possible_modules = json.loads(config_section["possible_modules"])
+        self.autostart_modules = json.loads(config_section["autostart_modules"])

--- a/aw_qt/main.py
+++ b/aw_qt/main.py
@@ -30,7 +30,7 @@ def parse_args():
                         help='Run the trayicon and services in testing mode')
     parser.add_argument('--autostart-modules', dest='autostart_modules',
                         type=lambda s: [m for m in s.split(',') if m and m.lower() != "none"],
-                        default=["aw-server", "aw-watcher-afk", "aw-watcher-window"],
+                        default=None,
                         help='A comma-separated list of modules to autostart, or just `none` to not autostart anything')
 
     return parser.parse_args()

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -7,6 +7,8 @@ from typing import Optional, List
 
 import aw_core
 
+from .config import QTSettings
+
 logger = logging.getLogger(__name__)
 
 
@@ -123,19 +125,9 @@ class Module:
 
 
 class Manager:
-    def __init__(self, testing: bool=False) -> None:
-        # TODO: Fetch these from somewhere appropriate (auto detect or a config file)
-        #       Save to config wether they should autostart or not.
-        _possible_modules = [
-            "aw-server",
-            "aw-watcher-afk",
-            "aw-watcher-window",
-            # "aw-watcher-spotify",
-            # "aw-watcher-network"
-        ]
-
-        # TODO: Filter away all modules not available on system
-        self.modules = {name: Module(name, testing=testing) for name in _possible_modules}
+    def __init__(self, testing: bool = False) -> None:
+        self.settings = QTSettings(testing)
+        self.modules = {name: Module(name, testing=testing) for name in self.settings.possible_modules}
 
     def get_unexpected_stops(self):
         return list(filter(lambda x: x.started and not x.is_alive(), self.modules.values()))
@@ -147,6 +139,11 @@ class Manager:
             logger.error("Unable to start module '{}': No such module".format(module_name))
 
     def autostart(self, autostart_modules):
+
+        if autostart_modules is None:
+            # Modules to start are not specified. Fallback on configuration.
+            autostart_modules = self.settings.autostart_modules
+
         # Always start aw-server first
         if "aw-server" in autostart_modules:
             self.start("aw-server")


### PR DESCRIPTION
NOTE: `ConfigParser` does not correctly store array values.
Store module lists as json.