### PR TITLE
Use monochrome-black trayicon on MacOS

### DIFF
--- a/aw_qt/resources.qrc
+++ b/aw_qt/resources.qrc
@@ -2,6 +2,7 @@
 <RCC version="1.0">
     <qresource>
         <file alias="logo.png">../media/logo/logo.png</file>
-        <file alias="monochrome-logo.png">../media/logo/black-monochrome-logo.png</file>
+        <file alias="black-monochrome-logo.png">../media/logo/black-monochrome-logo.png</file>
+        <file alias="white-monochrome-logo.png">../media/logo/white-monochrome-logo.png</file>
     </qresource>
 </RCC>

--- a/aw_qt/resources.qrc
+++ b/aw_qt/resources.qrc
@@ -2,5 +2,6 @@
 <RCC version="1.0">
     <qresource>
         <file alias="logo.png">../media/logo/logo.png</file>
+        <file alias="monochrome-logo.png">../media/logo/black-monochrome-logo.png</file>
     </qresource>
 </RCC>

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -166,8 +166,11 @@ def run(manager, testing=False):
         sys.exit(1)
 
     widget = QWidget()
+    if sys.platform == "darwin":
+        icon = QIcon(":/monochrome-logo.png")
+    else:
+        icon = QIcon(":/logo.png")
 
-    icon = QIcon(":/logo.png")
     trayIcon = TrayIcon(manager, icon, widget, testing=testing)
     trayIcon.show()
 

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -167,7 +167,12 @@ def run(manager, testing=False):
 
     widget = QWidget()
     if sys.platform == "darwin":
-        icon = QIcon(":/monochrome-logo.png")
+        from Foundation import NSUserDefaults
+        style = NSUserDefaults.standardUserDefaults().stringForKey_('AppleInterfaceStyle')
+        if style == "Dark":
+            icon = QIcon(":/white-monochrome-logo.png")
+        else:
+            icon = QIcon(":/black-monochrome-logo.png")
     else:
         icon = QIcon(":/logo.png")
 


### PR DESCRIPTION
Solves https://github.com/ActivityWatch/activitywatch/issues/239 . 
Requires https://github.com/ActivityWatch/media/pull/1