### PR TITLE
fix: removed poetry resources.py workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 .PHONY: build install test test-integration typecheck package clean
 
 build: aw_qt/resources.py
-	# Workaround for https://github.com/python-poetry/poetry/issues/1338#issuecomment-571618450
-	cp .gitignore .gitignore.backup
-	grep -v 'aw_qt/resources.py' .gitignore.backup > .gitignore
 	poetry install
-	mv .gitignore.backup .gitignore
-	rm -f .gitignore.backup
 
 install:
 	bash scripts/config-autostart.sh


### PR DESCRIPTION
Completely untested change. I just noticed that poetry seems to include the files in sdists now: https://github.com/python-poetry/poetry/issues/1338#issuecomment-658241544