### PR TITLE
fix: detect .bat and .cmd executables on Windows

### DIFF
--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -29,7 +29,11 @@ def is_executable(path: str, filename: str) -> bool:
         return False
     # On windows all files ending with .exe are executables
     if platform.system() == "Windows":
-        return filename.endswith(".exe")
+        return (
+            filename.endswith(".exe")
+            or filename.endswith(".bat")
+            or filename.endswith(".cmd")
+        )
     # On Unix platforms all files having executable permissions are executables
     # We do not however want to include .desktop files
     else:  # Assumes Unix
@@ -63,10 +67,10 @@ def _filename_to_name(filename: str) -> str:
 
 
 def _discover_modules_bundled() -> List["Module"]:
-    """Use ``_discover_modules_in_directory`` to find all bundled modules """
+    """Use ``_discover_modules_in_directory`` to find all bundled modules"""
     search_paths = [_module_dir, _parent_dir]
     if platform.system() == "Darwin":
-        macos_dir = os.path.abspath(os.path.join(_parent_dir, os.pardir, 'MacOS'))
+        macos_dir = os.path.abspath(os.path.join(_parent_dir, os.pardir, "MacOS"))
         search_paths.append(macos_dir)
     logger.info("Searching for bundled modules in: {}".format(search_paths))
 


### PR DESCRIPTION
Without this fix, aw-qt wouldn't detect modules as they end in `.cmd` or `.bat` (not sure which).

Reported here: https://discord.com/channels/755040852727955476/755334568977891348/956531050627104832

The user got the following output:

```
[INFO ]: Started aw-qt...  (aw_qt.main:31)
[INFO ]: Searching for bundled modules in: ['PATH \\activitywatch\\aw-qt\\aw_qt', PATH \\activitywatch\\aw-qt']  (aw_qt.manager:71)
[WARNING]: Found matching file but was not executable: PATH \activitywatch\aw-qt\aw-qt.spec  (aw_qt.manager:55)
[INFO ]: Found bundled modules:  (aw_qt.manager:77)
[INFO ]: Found system modules:  (aw_qt.manager:104)
[INFO ]:  - aw-client at PATH \venv\Scripts\aw-client.exe  (aw_qt.manager:24)
[ERROR]: Module aw-server not found  (aw_qt.manager:270)
[ERROR]: Module aw-watcher-afk not found  (aw_qt.manager:270)
[ERROR]: Module aw-watcher-window not found  (aw_qt.manager:270)
[ERROR]: Manager tried to start nonexistent module aw-server  (aw_qt.manager:260)
[ERROR]: Manager tried to start nonexistent module aw-watcher-afk  (aw_qt.manager:260)
[ERROR]: Manager tried to start nonexistent module aw-watcher-window  (aw_qt.manager:260)
[INFO ]: Creating trayicon...  (aw_qt.trayicon:206)
[INFO ]: Initialized aw-qt and trayicon succesfully  (aw_qt.trayicon:245) 
```

Not sure why aw-client becomes an .exe but aw-server etc becomes a .bat or .cmd