### PR TITLE
Remove upper version requirement on Python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 aw-qt = "aw_qt:main"
 
 [tool.poetry.dependencies]
-python = "^3.8,<3.13"
+python = "^3.8"
 aw-core = "^0.5"
 
 pyobjc-framework-Cocoa = { version = "*", platform = "darwin" }


### PR DESCRIPTION
aw-qt fails to build on Fedora 41, because it requires Python < 3.13 and Fedora uses Python 3.13. It works fine with the latest version of Python though.

This patch is intended to help with Fedora packaging by assuming that aw-qt works on the latest Python instead of requiring the packager to test it manually with every major release of Python.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 37540bc1cdf2ae344dc5ba526fba1dc3b9b4e757  | 
|--------|--------|

### Summary:
Removed the upper version limit on Python in `pyproject.toml` to support Python 3.13 and future versions.

**Key points**:
- Modified `pyproject.toml` to remove the upper version limit on Python.
- Changed `python` dependency from `^3.8,<3.13` to `^3.8`.
- Ensures compatibility with Python 3.13 and future versions.
- Helps with Fedora packaging by avoiding manual testing for each Python release.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->