### PR TITLE
fix(trayicon): re-apply tooltip after show() to fix empty tooltip on Windows 11

### DIFF
--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -259,6 +259,12 @@ def run(manager: Manager, testing: bool = False) -> Any:
     trayIcon = TrayIcon(manager, icon, widget, testing=testing)
     trayIcon.show()
 
+    # Re-apply tooltip after show() to ensure it registers with the
+    # platform's system tray backend.  On Windows 11 the tooltip can
+    # appear empty when it is only set before the icon is visible.
+    # See: https://github.com/ActivityWatch/aw-qt/issues/112
+    trayIcon.setToolTip(trayIcon.toolTip())
+
     QApplication.setQuitOnLastWindowClosed(False)
 
     logger.info("Initialized aw-qt and trayicon successfully")


### PR DESCRIPTION
## Summary
- Re-applies the tooltip text after `trayIcon.show()` to ensure the Windows system tray backend registers it
- On Windows 11, tooltips set before `show()` may not be picked up, resulting in an empty tooltip on hover
- The fix is a no-op on platforms where the tooltip already works correctly

## Test plan
- [ ] Hover over the ActivityWatch tray icon on Windows 11 and verify the tooltip shows "ActivityWatch"
- [ ] Verify no regression on macOS and Linux

Fixes #112
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-applies tooltip after `trayIcon.show()` in `trayicon.py` to fix empty tooltip issue on Windows 11.
> 
>   - **Behavior**:
>     - Re-applies tooltip in `run()` in `trayicon.py` after `trayIcon.show()` to fix empty tooltip issue on Windows 11.
>     - No-op on macOS and Linux.
>   - **Test Plan**:
>     - Verify tooltip shows on Windows 11.
>     - Ensure no regression on macOS and Linux.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-qt&utm_source=github&utm_medium=referral)<sup> for abde3d2640210881cc2a4b5c37e70805b29b314c. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->