### PR TITLE
fix(trayicon): wait for system tray availability on startup

### DIFF
--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -242,20 +242,20 @@ def run(manager: Manager, testing: bool = False) -> Any:
     # root widget
     widget = QWidget()
 
-    # Wait for system tray to become available (up to 30 s).
+    # Wait for system tray to become available (up to 10 s).
     # On some desktop environments (e.g. KDE Plasma), autostart programs
     # launch before the panel/system tray is loaded.  Qt docs note that
     # "if the system tray is currently unavailable but becomes available
     # later, QSystemTrayIcon will automatically add an entry."
     # See: https://github.com/ActivityWatch/aw-qt/issues/97
     if not QSystemTrayIcon.isSystemTrayAvailable():
-        logger.info("System tray not yet available, waiting up to 30 s...")
-        for i in range(30):
+        logger.info("System tray not yet available, waiting up to 10 s...")
+        for i in range(10):
             time.sleep(1)
             # Process events so Qt can detect tray availability changes
             app.processEvents()
             if QSystemTrayIcon.isSystemTrayAvailable():
-                logger.info(f"System tray became available after {i + 1} s")
+                logger.info(f"System tray became available after {i + 1}s")
                 break
         else:
             QMessageBox.critical(


### PR DESCRIPTION
## Summary
- Instead of immediately exiting when the system tray isn't available, polls for up to 30 seconds
- Calls `app.processEvents()` during the wait so Qt can detect when the tray becomes available
- Falls back to the original error dialog if the tray never appears
- Fixes the issue on KDE Plasma (and similar DEs) where autostart programs launch before the panel is loaded

## Test plan
- [ ] On KDE Plasma with aw-qt in autostart, verify it waits and successfully starts
- [ ] On a system with a system tray, verify no delay (the check passes immediately)
- [ ] On a headless system with no tray, verify it exits after 30s with the error dialog

Fixes #97
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Poll for system tray availability for up to 30 seconds on startup in `run()` in `trayicon.py`, addressing KDE Plasma startup issues.
> 
>   - **Behavior**:
>     - In `run()` in `trayicon.py`, poll for system tray availability for up to 30 seconds on startup.
>     - Call `app.processEvents()` during the wait to detect tray availability changes.
>     - Exit with error dialog if tray is unavailable after 30 seconds.
>   - **Environment**:
>     - Fixes startup issue on KDE Plasma where autostart programs launch before the panel is loaded.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-qt&utm_source=github&utm_medium=referral)<sup> for f071fe064acc518418f84fc380493e99b1a1586d. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->