### PR TITLE
fix(manager): skip ignored files early to suppress spurious warnings

### DIFF
--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -55,8 +55,10 @@ def _discover_modules_in_directory(path: str) -> List["Module"]:
     matches = glob(os.path.join(path, "aw-*"))
     for path in matches:
         basename = os.path.basename(path)
+        name = _filename_to_name(basename)
+        if name in ignored_filenames:
+            continue
         if is_executable(path, basename) and basename.startswith("aw-"):
-            name = _filename_to_name(basename)
             modules.append(Module(name, Path(path), "bundled"))
         elif os.path.isdir(path) and os.access(path, os.X_OK):
             modules.extend(_discover_modules_in_directory(path))


### PR DESCRIPTION
## Problem

Files like `aw-qt.spec` (the PyInstaller spec file) are already in `ignored_filenames`, but the discovery loop only applied `filter_modules()` _after_ building the module list. This meant non-executable files matching `aw-*` (e.g. `aw-qt.spec` on Windows) still hit the warning branch before being filtered out, resulting in:

```
[WARNING]: Found matching file but was not executable: C:\Users\...\aw-qt\aw-qt.spec
```

This confused users since it looks like an error but is actually harmless. Reported in #110.

## Fix

Skip `ignored_filenames` at the top of the loop so they never reach the warning branch. Also hoists `_filename_to_name()` so it's computed once and reused.

## Changes

- `_discover_modules_in_directory`: early `continue` for ignored filenames
- Moves `name = _filename_to_name(basename)` before the `is_executable` check

No behavior change for any legitimate module — only suppresses the spurious warning for files that were already going to be ignored.