### PR TITLE
fix(manager): detect .bat and .cmd executables and strip extensions on Windows

### DIFF
--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -29,7 +29,11 @@ def is_executable(path: str, filename: str) -> bool:
         return False
     # On windows all files ending with .exe are executables
     if platform.system() == "Windows":
-        return filename.endswith(".exe")
+        return (
+            filename.endswith(".exe")
+            or filename.endswith(".bat")
+            or filename.endswith(".cmd")
+        )
     # On Unix platforms all files having executable permissions are executables
     # We do not however want to include .desktop files
     else:  # Assumes Unix
@@ -63,10 +67,10 @@ def _filename_to_name(filename: str) -> str:
 
 
 def _discover_modules_bundled() -> List["Module"]:
-    """Use ``_discover_modules_in_directory`` to find all bundled modules """
+    """Use ``_discover_modules_in_directory`` to find all bundled modules"""
     search_paths = [_module_dir, _parent_dir]
     if platform.system() == "Darwin":
-        macos_dir = os.path.abspath(os.path.join(_parent_dir, os.pardir, 'MacOS'))
+        macos_dir = os.path.abspath(os.path.join(_parent_dir, os.pardir, "MacOS"))
         search_paths.append(macos_dir)
     logger.info("Searching for bundled modules in: {}".format(search_paths))
 

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -63,7 +63,11 @@ def _discover_modules_in_directory(path: str) -> List["Module"]:
 
 
 def _filename_to_name(filename: str) -> str:
-    return filename.replace(".exe", "")
+    if platform.system() == "Windows":
+        for ext in (".exe", ".bat", ".cmd"):
+            if filename.endswith(ext):
+                return filename[: -len(ext)]
+    return filename
 
 
 def _discover_modules_bundled() -> List["Module"]:

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -27,7 +27,7 @@ def _log_modules(modules: List["Module"]) -> None:
 def is_executable(path: str, filename: str) -> bool:
     if not os.path.isfile(path):
         return False
-    # On windows all files ending with .exe are executables
+    # On Windows, .exe/.bat/.cmd files are executables
     if platform.system() == "Windows":
         return (
             filename.endswith(".exe")


### PR DESCRIPTION
Closes/completes #81.

## Changes

1. **`is_executable()`** — adds `.bat` and `.cmd` as recognised executable extensions on Windows (original commit from #81).
2. **`_filename_to_name()`** — also strips `.bat` / `.cmd` extensions so discovered modules get the right names (`aw-server` not `aw-server.cmd`). Without this, autostart matching, module exclusion, and start-by-name lookups would all break. This was the remaining bug flagged by Greptile in #81.

## Why a new PR

The branch on the ActivityWatch org (`dev/detect-bat-cmd-windows-exes`) is Erik's and I don't have push access, so the fix is on my fork instead. Supersedes #81.

## Testing

Manual verification that `_filename_to_name` now returns the correct name for all three Windows launcher extensions:

```
aw-server.exe  -> aw-server  ✓
aw-server.cmd  -> aw-server  ✓
aw-server.bat  -> aw-server  ✓
aw-server      -> aw-server  ✓  (non-Windows / no extension)
```