### PR TITLE
feat(autostart): user-toggleable OS-level autostart (login item) support

### DIFF
--- a/aw_qt/autostart.py
+++ b/aw_qt/autostart.py
@@ -46,6 +46,8 @@ APP_NAME = "ActivityWatch"
 
 # Linux
 DESKTOP_FILENAME = "aw-qt.desktop"
+# Characters that force an Exec argument to be quoted (Desktop Entry Spec)
+_DESKTOP_RESERVED_CHARS = " \t\n\"'\\><~|&;$*?#()`"
 
 # macOS
 LAUNCH_AGENT_LABEL = "net.activitywatch.aw-qt"
@@ -163,10 +165,31 @@ def _bundled_desktop_file() -> Optional[Path]:
     return None
 
 
-def _desktop_exec_value() -> str:
-    import shlex
+def _desktop_quote_arg(arg: str) -> str:
+    """Quote a single Exec argument per the Desktop Entry Specification.
 
-    return " ".join(shlex.quote(arg) for arg in _command())
+    Desktop entries do *not* use POSIX shell quoting (so `shlex.quote` and its
+    single quotes are wrong here): arguments containing reserved characters
+    must be enclosed in double quotes, within which `"`, `` ` ``, `$` and `\\`
+    are escaped with a backslash.  Those backslashes are then doubled, because
+    the value is additionally subject to the desktop entry string escape rules.
+    A literal percent sign is written as `%%`, since `%` introduces a field code.
+
+    See: https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
+    """
+    arg = arg.replace("%", "%%")
+    if not arg:
+        return '""'
+    if not any(c in _DESKTOP_RESERVED_CHARS for c in arg):
+        return arg
+    quoted = "".join("\\" + c if c in '"`$\\' else c for c in arg)
+    # String-value escaping: a backslash in a desktop entry value is written as `\\`
+    quoted = quoted.replace("\\", "\\\\")
+    return f'"{quoted}"'
+
+
+def _desktop_exec_value() -> str:
+    return " ".join(_desktop_quote_arg(arg) for arg in _command())
 
 
 def _desktop_entry_contents() -> str:

--- a/aw_qt/autostart.py
+++ b/aw_qt/autostart.py
@@ -1,0 +1,512 @@
+"""
+OS-level autostart ("start at login") support for aw-qt.
+
+This module manages *login items*: getting the operating system to launch aw-qt
+when the user logs in.  It is unrelated to the ``autostart_modules`` setting in
+:mod:`aw_qt.config`, which decides which ActivityWatch modules aw-qt starts once
+it is already running.
+
+Public API:
+
+- :func:`is_enabled` -- whether aw-qt is currently registered to start at login
+- :func:`enable` -- register aw-qt as a login item
+- :func:`disable` -- unregister aw-qt as a login item
+
+(plus :func:`is_supported`, so callers can hide the option on platforms where
+no backend exists)
+
+All operations are idempotent: enabling something already enabled (or disabling
+something already disabled) is a no-op and never raises.  Failures that are not
+recoverable (read-only home directory, missing registry permissions, ...) raise
+:class:`AutostartError` from :func:`enable`/:func:`disable`, so the caller can
+show a message instead of crashing.  :func:`is_enabled` never raises; it logs
+and reports ``False`` if the state cannot be determined.
+
+Backends (stdlib only, no extra dependencies):
+
+- Linux: ``$XDG_CONFIG_HOME/autostart/aw-qt.desktop`` (defaults to
+  ``~/.config/autostart``), same location as ``scripts/config-autostart.sh``.
+- macOS: a LaunchAgent plist at
+  ``~/Library/LaunchAgents/net.activitywatch.aw-qt.plist`` with ``RunAtLoad``.
+- Windows: the ``HKCU\\...\\CurrentVersion\\Run`` registry value, *plus*
+  detection of the Startup-folder shortcut created by the installer.
+"""
+
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Callable, Dict, List, NamedTuple, Optional
+
+logger = logging.getLogger(__name__)
+
+APP_NAME = "ActivityWatch"
+
+# Linux
+DESKTOP_FILENAME = "aw-qt.desktop"
+
+# macOS
+LAUNCH_AGENT_LABEL = "net.activitywatch.aw-qt"
+LAUNCH_AGENT_FILENAME = f"{LAUNCH_AGENT_LABEL}.plist"
+
+# Windows
+WINDOWS_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+WINDOWS_RUN_VALUE_NAME = APP_NAME
+# Created by the Inno Setup installer when the user ticks
+# "Start ActivityWatch when Windows starts" ({userstartup} in activitywatch-setup.iss)
+WINDOWS_STARTUP_SHORTCUT_NAME = f"{APP_NAME}.lnk"
+
+# Fallback used when the packaged resources/aw-qt.desktop cannot be found
+_DESKTOP_TEMPLATE = """[Desktop Entry]
+Name=ActivityWatch
+GenericName=Time-tracking application
+Comment=Open source time-tracking application with a focus on extensibility and privacy.
+Exec={exec}
+Hidden=false
+StartupNotify=true
+Terminal=false
+Type=Application
+X-GNOME-Autostart-enabled=true
+Version=1.0
+Icon=activitywatch
+Categories=Utility;
+"""
+
+
+class AutostartError(Exception):
+    """Raised when autostart could not be enabled or disabled."""
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _home() -> Path:
+    """Return the user's home directory (indirection makes tests easy to isolate)."""
+    return Path(os.path.expanduser("~"))
+
+
+def _command() -> List[str]:
+    """The command the OS should run at login."""
+    if getattr(sys, "frozen", False):
+        # PyInstaller bundle: sys.executable is the aw-qt binary itself
+        return [sys.executable]
+
+    import shutil
+
+    exe = shutil.which("aw-qt")
+    if exe:
+        return [exe]
+
+    # Running from a source checkout
+    return [sys.executable, "-m", "aw_qt"]
+
+
+def _write_text_atomic(path: Path, contents: str) -> None:
+    """Write `contents` to `path`, replacing any existing file atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmppath = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(contents)
+        os.replace(tmppath, path)
+    except BaseException:
+        try:
+            os.unlink(tmppath)
+        except OSError:
+            pass
+        raise
+
+
+def _remove_file(path: Path) -> None:
+    """Remove `path` if it exists. Missing files are not an error (idempotency)."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Linux: XDG autostart .desktop file
+# ---------------------------------------------------------------------------
+
+
+def _linux_autostart_dir() -> Path:
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return Path(config_home) / "autostart"
+    return _home() / ".config" / "autostart"
+
+
+def _linux_desktop_path() -> Path:
+    return _linux_autostart_dir() / DESKTOP_FILENAME
+
+
+def _bundled_desktop_file() -> Optional[Path]:
+    """Locate the shipped resources/aw-qt.desktop, if available."""
+    candidates = []
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        # aw-qt.spec bundles it at the top level of the PyInstaller dir
+        candidates.append(Path(meipass) / DESKTOP_FILENAME)
+    candidates.append(
+        Path(__file__).resolve().parent.parent / "resources" / DESKTOP_FILENAME
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _desktop_exec_value() -> str:
+    import shlex
+
+    return " ".join(shlex.quote(arg) for arg in _command())
+
+
+def _desktop_entry_contents() -> str:
+    """Build the .desktop entry, reusing the packaged one when we can find it."""
+    exec_value = _desktop_exec_value()
+    source = _bundled_desktop_file()
+    if source is not None:
+        try:
+            text = source.read_text(encoding="utf-8")
+        except OSError as e:
+            logger.warning(f"Could not read {source}, using built-in template: {e}")
+        else:
+            return _with_exec(text, exec_value)
+    return _DESKTOP_TEMPLATE.format(**{"exec": exec_value})
+
+
+def _with_exec(desktop_entry: str, exec_value: str) -> str:
+    """Return `desktop_entry` with Exec= pointing at our command and Hidden=false."""
+    lines = []
+    has_exec = False
+    for line in desktop_entry.splitlines():
+        key = line.split("=", 1)[0].strip().lower()
+        if key == "exec":
+            lines.append(f"Exec={exec_value}")
+            has_exec = True
+        elif key == "hidden":
+            # Desktop environments write Hidden=true to disable an entry
+            lines.append("Hidden=false")
+        else:
+            lines.append(line)
+    if not has_exec:
+        lines.append(f"Exec={exec_value}")
+    return "\n".join(lines) + "\n"
+
+
+def _linux_is_enabled() -> bool:
+    path = _linux_desktop_path()
+    if not path.is_file():
+        return False
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        logger.warning(f"Could not read {path}: {e}")
+        # The file exists, so autostart is (most likely) enabled
+        return True
+    for line in text.splitlines():
+        parts = line.split("=", 1)
+        if len(parts) != 2:
+            continue
+        key, value = parts[0].strip().lower(), parts[1].strip().lower()
+        # Both are used by desktop environments to disable an autostart entry
+        if key == "hidden" and value == "true":
+            return False
+        if key == "x-gnome-autostart-enabled" and value == "false":
+            return False
+    return True
+
+
+def _linux_enable() -> None:
+    _write_text_atomic(_linux_desktop_path(), _desktop_entry_contents())
+
+
+def _linux_disable() -> None:
+    _remove_file(_linux_desktop_path())
+
+
+# ---------------------------------------------------------------------------
+# macOS: LaunchAgent plist
+#
+# NOTE: we deliberately do *not* call `launchctl load/unload`.
+#   - `launchctl load -w` would immediately start a second aw-qt (because of
+#     RunAtLoad), which the single-instance lock then kills off again.
+#   - `launchctl unload` would terminate the running instance that launchd
+#     started at login -- i.e. quitting the app the user just clicked in.
+# launchd scans ~/Library/LaunchAgents at every login, so writing/removing the
+# plist is enough for the setting to take effect from the next login onwards,
+# which is exactly the semantics of a login item.
+# ---------------------------------------------------------------------------
+
+
+def _macos_plist_path() -> Path:
+    return _home() / "Library" / "LaunchAgents" / LAUNCH_AGENT_FILENAME
+
+
+def _macos_plist_contents() -> bytes:
+    import plistlib
+
+    return plistlib.dumps(
+        {
+            "Label": LAUNCH_AGENT_LABEL,
+            "ProgramArguments": _command(),
+            "RunAtLoad": True,
+            # aw-qt manages its own subprocesses and should not be respawned by
+            # launchd when the user quits it from the tray
+            "KeepAlive": False,
+            "ProcessType": "Interactive",
+        }
+    )
+
+
+def _macos_is_enabled() -> bool:
+    return _macos_plist_path().is_file()
+
+
+def _macos_enable() -> None:
+    path = _macos_plist_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    contents = _macos_plist_contents()
+    fd, tmppath = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(contents)
+        os.replace(tmppath, path)
+    except BaseException:
+        try:
+            os.unlink(tmppath)
+        except OSError:
+            pass
+        raise
+
+
+def _macos_disable() -> None:
+    _remove_file(_macos_plist_path())
+
+
+# ---------------------------------------------------------------------------
+# Windows: HKCU Run key + installer Startup shortcut
+#
+# Precedence: the installer's Startup-folder shortcut counts as "enabled".
+# If it is present we do *not* also write the Run key (that would start aw-qt
+# twice), and disabling removes both, otherwise the toggle would appear to do
+# nothing for everyone who ticked the installer checkbox.
+# ---------------------------------------------------------------------------
+
+
+def _windows_startup_dir() -> Optional[Path]:
+    """The user's Startup folder, or None if it cannot be determined."""
+    if sys.platform == "win32":
+        import winreg
+
+        try:
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
+            ) as key:
+                value, _type = winreg.QueryValueEx(key, "Startup")
+            if value:
+                return Path(str(value))
+        except OSError as e:
+            logger.debug(f"Could not read Startup folder from registry: {e}")
+
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(
+                appdata, "Microsoft", "Windows", "Start Menu", "Programs", "Startup"
+            )
+    return None
+
+
+def _windows_startup_shortcut() -> Optional[Path]:
+    """Path to the installer-created Startup shortcut, if it exists."""
+    startup_dir = _windows_startup_dir()
+    if startup_dir is None:
+        return None
+    shortcut = startup_dir / WINDOWS_STARTUP_SHORTCUT_NAME
+    try:
+        if shortcut.is_file():
+            return shortcut
+    except OSError as e:
+        logger.debug(f"Could not stat {shortcut}: {e}")
+    return None
+
+
+def _windows_run_value() -> Optional[str]:
+    """The HKCU Run value for ActivityWatch, or None if it is not set."""
+    if sys.platform == "win32":
+        import winreg
+
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, WINDOWS_RUN_KEY) as key:
+                value, _type = winreg.QueryValueEx(key, WINDOWS_RUN_VALUE_NAME)
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            raise AutostartError(f"Could not read the registry: {e}") from e
+        return str(value)
+    return None
+
+
+def _windows_set_run_value(command: str) -> None:
+    if sys.platform == "win32":
+        import winreg
+
+        try:
+            with winreg.CreateKeyEx(
+                winreg.HKEY_CURRENT_USER, WINDOWS_RUN_KEY, 0, winreg.KEY_SET_VALUE
+            ) as key:
+                winreg.SetValueEx(
+                    key, WINDOWS_RUN_VALUE_NAME, 0, winreg.REG_SZ, command
+                )
+        except OSError as e:
+            raise AutostartError(f"Could not write to the registry: {e}") from e
+
+
+def _windows_delete_run_value() -> None:
+    if sys.platform == "win32":
+        import winreg
+
+        try:
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER, WINDOWS_RUN_KEY, 0, winreg.KEY_SET_VALUE
+            ) as key:
+                winreg.DeleteValue(key, WINDOWS_RUN_VALUE_NAME)
+        except FileNotFoundError:
+            # Key or value is already gone
+            pass
+        except OSError as e:
+            raise AutostartError(f"Could not write to the registry: {e}") from e
+
+
+def _windows_delete_startup_shortcut() -> None:
+    shortcut = _windows_startup_shortcut()
+    if shortcut is None:
+        return
+    try:
+        shortcut.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        raise AutostartError(f"Could not remove {shortcut}: {e}") from e
+
+
+def _windows_is_enabled() -> bool:
+    if _windows_startup_shortcut() is not None:
+        return True
+    return _windows_run_value() is not None
+
+
+def _windows_enable() -> None:
+    if _windows_startup_shortcut() is not None:
+        # Already started by the installer's Startup shortcut, adding the Run
+        # key as well would launch aw-qt twice
+        logger.info("Autostart already enabled via the Startup folder shortcut")
+        return
+    _windows_set_run_value(subprocess.list2cmdline(_command()))
+
+
+def _windows_disable() -> None:
+    _windows_delete_run_value()
+    _windows_delete_startup_shortcut()
+
+
+# ---------------------------------------------------------------------------
+# platform dispatch
+# ---------------------------------------------------------------------------
+
+
+class _Backend(NamedTuple):
+    is_enabled: Callable[[], bool]
+    enable: Callable[[], None]
+    disable: Callable[[], None]
+
+
+_BACKENDS: Dict[str, _Backend] = {
+    "linux": _Backend(_linux_is_enabled, _linux_enable, _linux_disable),
+    "darwin": _Backend(_macos_is_enabled, _macos_enable, _macos_disable),
+    "windows": _Backend(_windows_is_enabled, _windows_enable, _windows_disable),
+}
+
+
+def _platform_key(platform_name: Optional[str] = None) -> Optional[str]:
+    """Map a sys.platform string onto a backend name, or None if unsupported."""
+    name = sys.platform if platform_name is None else platform_name
+    if name.startswith("linux") or "bsd" in name:
+        # The *BSDs use the same XDG autostart directory as Linux
+        return "linux"
+    if name == "darwin":
+        return "darwin"
+    if name == "win32":
+        return "windows"
+    return None
+
+
+def _get_backend(platform_name: Optional[str] = None) -> Optional[_Backend]:
+    key = _platform_key(platform_name)
+    return _BACKENDS[key] if key is not None else None
+
+
+def is_supported(platform_name: Optional[str] = None) -> bool:
+    """Whether autostart can be managed on this platform."""
+    return _get_backend(platform_name) is not None
+
+
+def is_enabled() -> bool:
+    """Whether aw-qt is currently registered to start at login.
+
+    Never raises: an unsupported platform or an unreadable
+    file/registry key is reported as `False`.
+    """
+    backend = _get_backend()
+    if backend is None:
+        return False
+    try:
+        return backend.is_enabled()
+    except Exception as e:
+        logger.warning(f"Could not determine autostart status: {e}")
+        return False
+
+
+def enable() -> None:
+    """Register aw-qt to start at login. No-op if already enabled.
+
+    Raises AutostartError if the change could not be made.
+    """
+    backend = _get_backend()
+    if backend is None:
+        raise AutostartError(f"Autostart is not supported on {sys.platform}")
+    try:
+        backend.enable()
+    except AutostartError:
+        raise
+    except Exception as e:
+        raise AutostartError(f"Could not enable autostart: {e}") from e
+    logger.info("Enabled autostart")
+
+
+def disable() -> None:
+    """Unregister aw-qt from starting at login. No-op if already disabled.
+
+    Raises AutostartError if the change could not be made.
+    """
+    backend = _get_backend()
+    if backend is None:
+        raise AutostartError(f"Autostart is not supported on {sys.platform}")
+    try:
+        backend.disable()
+    except AutostartError:
+        raise
+    except Exception as e:
+        raise AutostartError(f"Could not disable autostart: {e}") from e
+    logger.info("Disabled autostart")

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import aw_core
 from PyQt6 import QtCore
-from PyQt6.QtGui import QIcon
+from PyQt6.QtGui import QAction, QIcon
 from PyQt6.QtWidgets import (
     QApplication,
     QMenu,
@@ -20,6 +20,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from . import autostart
 from .manager import Manager, Module
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,7 @@ class TrayIcon(QSystemTrayIcon):
         self.manager = manager
         self.testing = testing
         self._restart_timestamps: Dict[str, List[float]] = {}
+        self._autostart_action: Optional[QAction] = None
 
         if port is None:
             port = 5666 if testing else 5600
@@ -115,6 +117,33 @@ class TrayIcon(QSystemTrayIcon):
         self._restart_timestamps[module_name] = [
             t for t in timestamps if t > cutoff
         ] + [now]
+
+    def _refresh_autostart_action(self) -> None:
+        """Sync the menu item with the actual OS-level autostart state."""
+        if self._autostart_action is not None:
+            self._autostart_action.setChecked(autostart.is_enabled())
+
+    def _on_autostart_toggled(self) -> None:
+        """Enable/disable starting ActivityWatch at login."""
+        if self._autostart_action is None:
+            return
+        # The action is checkable, so it already holds the state the user asked for
+        checked = self._autostart_action.isChecked()
+        try:
+            if checked:
+                autostart.enable()
+            else:
+                autostart.disable()
+        except autostart.AutostartError as e:
+            logger.error(f"Failed to change autostart setting: {e}")
+            box = QMessageBox(self._parent)
+            box.setIcon(QMessageBox.Icon.Warning)
+            action = "enable" if checked else "disable"
+            box.setText(f"Could not {action} starting ActivityWatch at login.")
+            box.setDetailedText(str(e))
+            box.show()
+        # Always reflect the real state, the toggle may have failed
+        self._refresh_autostart_action()
 
     def on_activated(self, reason: QSystemTrayIcon.ActivationReason) -> None:
         if reason == QSystemTrayIcon.ActivationReason.DoubleClick:
@@ -143,6 +172,17 @@ class TrayIcon(QSystemTrayIcon):
         menu.addAction(
             "Open config folder", lambda: open_dir(aw_core.dirs.get_config_dir(None))
         )
+
+        if autostart.is_supported():
+            self._autostart_action = menu.addAction(
+                "Start at login", self._on_autostart_toggled
+            )
+            self._autostart_action.setCheckable(True)
+            self._autostart_action.setChecked(autostart.is_enabled())
+            # Autostart can also be changed outside of aw-qt, so re-read the
+            # actual state every time the menu is opened
+            menu.aboutToShow.connect(self._refresh_autostart_action)
+
         menu.addSeparator()
 
         exitIcon = QIcon.fromTheme(

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,309 @@
+"""Unit tests for OS-level autostart (login item) management.
+
+The OS layer is mocked throughout, so these tests never touch the real home
+directory or registry and run on any platform.
+"""
+
+import plistlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from aw_qt import autostart
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Point the autostart module at a throwaway home directory."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    with patch.object(autostart, "_home", return_value=home):
+        yield home
+
+
+class TestPlatformSelection:
+    """Tests for mapping sys.platform onto a backend."""
+
+    @pytest.mark.parametrize(
+        "platform_name,expected",
+        [
+            ("linux", "linux"),
+            ("linux2", "linux"),
+            ("freebsd13", "linux"),
+            ("darwin", "darwin"),
+            ("win32", "windows"),
+        ],
+    )
+    def test_supported_platforms(self, platform_name, expected):
+        assert autostart._platform_key(platform_name) == expected
+        assert autostart.is_supported(platform_name)
+
+    @pytest.mark.parametrize("platform_name", ["aix", "emscripten", "cygwin", ""])
+    def test_unsupported_platforms(self, platform_name):
+        assert autostart._platform_key(platform_name) is None
+        assert not autostart.is_supported(platform_name)
+
+    def test_backend_functions_match_platform(self):
+        assert autostart._get_backend("linux").enable is autostart._linux_enable
+        assert autostart._get_backend("darwin").enable is autostart._macos_enable
+        assert autostart._get_backend("win32").enable is autostart._windows_enable
+
+    def test_default_platform_is_current(self):
+        import sys
+
+        assert autostart._platform_key() == autostart._platform_key(sys.platform)
+
+    def test_enable_raises_on_unsupported_platform(self):
+        with patch.object(autostart, "_get_backend", return_value=None):
+            with pytest.raises(autostart.AutostartError):
+                autostart.enable()
+            with pytest.raises(autostart.AutostartError):
+                autostart.disable()
+            # is_enabled must never raise
+            assert autostart.is_enabled() is False
+
+
+class TestPublicApiErrorHandling:
+    def test_is_enabled_never_raises(self):
+        backend = autostart._Backend(
+            is_enabled=lambda: (_ for _ in ()).throw(OSError("boom")),
+            enable=lambda: None,
+            disable=lambda: None,
+        )
+        with patch.object(autostart, "_get_backend", return_value=backend):
+            assert autostart.is_enabled() is False
+
+    def test_backend_errors_become_autostart_errors(self):
+        def _boom():
+            raise OSError("read-only file system")
+
+        backend = autostart._Backend(
+            is_enabled=lambda: False, enable=_boom, disable=_boom
+        )
+        with patch.object(autostart, "_get_backend", return_value=backend):
+            with pytest.raises(autostart.AutostartError, match="read-only"):
+                autostart.enable()
+            with pytest.raises(autostart.AutostartError, match="read-only"):
+                autostart.disable()
+
+
+class TestLinuxBackend:
+    def test_uses_xdg_config_home(self, fake_home, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        assert autostart._linux_desktop_path() == (
+            tmp_path / "xdg" / "autostart" / "aw-qt.desktop"
+        )
+
+    def test_falls_back_to_dot_config(self, fake_home):
+        assert autostart._linux_desktop_path() == (
+            fake_home / ".config" / "autostart" / "aw-qt.desktop"
+        )
+
+    def test_enable_creates_desktop_file(self, fake_home):
+        assert not autostart._linux_is_enabled()
+
+        autostart._linux_enable()
+
+        path = autostart._linux_desktop_path()
+        assert path.is_file()
+        contents = path.read_text()
+        assert "[Desktop Entry]" in contents
+        assert "Type=Application" in contents
+        assert any(line.startswith("Exec=") for line in contents.splitlines())
+        assert autostart._linux_is_enabled()
+
+    def test_enable_is_idempotent(self, fake_home):
+        autostart._linux_enable()
+        first = autostart._linux_desktop_path().read_text()
+        autostart._linux_enable()
+        assert autostart._linux_desktop_path().read_text() == first
+        assert autostart._linux_is_enabled()
+
+    def test_disable_removes_desktop_file(self, fake_home):
+        autostart._linux_enable()
+        autostart._linux_disable()
+        assert not autostart._linux_desktop_path().exists()
+        assert not autostart._linux_is_enabled()
+
+    def test_disable_is_idempotent(self, fake_home):
+        # Disabling when nothing is enabled must not raise
+        autostart._linux_disable()
+        autostart._linux_disable()
+        assert not autostart._linux_is_enabled()
+
+    def test_enable_reenables_hidden_entry(self, fake_home):
+        """A desktop environment may disable the entry with Hidden=true."""
+        path = autostart._linux_desktop_path()
+        path.parent.mkdir(parents=True)
+        path.write_text("[Desktop Entry]\nType=Application\nExec=aw-qt\nHidden=true\n")
+        assert not autostart._linux_is_enabled()
+
+        autostart._linux_enable()
+
+        assert autostart._linux_is_enabled()
+        assert "Hidden=false" in path.read_text()
+
+    def test_gnome_autostart_disabled_reads_as_disabled(self, fake_home):
+        path = autostart._linux_desktop_path()
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            "[Desktop Entry]\nType=Application\nExec=aw-qt\n"
+            "X-GNOME-Autostart-enabled=false\n"
+        )
+        assert not autostart._linux_is_enabled()
+
+    def test_reuses_packaged_desktop_file(self, fake_home, tmp_path):
+        packaged = tmp_path / "aw-qt.desktop"
+        packaged.write_text(
+            "[Desktop Entry]\nName=ActivityWatch\nExec=aw-qt\nIcon=activitywatch\n"
+        )
+        with patch.object(autostart, "_bundled_desktop_file", return_value=packaged):
+            with patch.object(
+                autostart, "_command", return_value=["/opt/aw/aw-qt", "--flag"]
+            ):
+                autostart._linux_enable()
+
+        contents = autostart._linux_desktop_path().read_text()
+        assert "Icon=activitywatch" in contents
+        assert "Exec=/opt/aw/aw-qt --flag" in contents
+
+    def test_exec_value_is_quoted(self):
+        with patch.object(
+            autostart, "_command", return_value=["/path with space/aw-qt"]
+        ):
+            assert autostart._desktop_exec_value() == "'/path with space/aw-qt'"
+
+
+class TestMacosBackend:
+    def test_plist_path(self, fake_home):
+        assert autostart._macos_plist_path() == (
+            fake_home / "Library" / "LaunchAgents" / "net.activitywatch.aw-qt.plist"
+        )
+
+    def test_enable_writes_launch_agent(self, fake_home):
+        assert not autostart._macos_is_enabled()
+
+        with patch.object(autostart, "_command", return_value=["/opt/aw/aw-qt"]):
+            autostart._macos_enable()
+
+        path = autostart._macos_plist_path()
+        assert path.is_file()
+        with path.open("rb") as f:
+            plist = plistlib.load(f)
+        assert plist["Label"] == "net.activitywatch.aw-qt"
+        assert plist["RunAtLoad"] is True
+        assert plist["ProgramArguments"] == ["/opt/aw/aw-qt"]
+        assert autostart._macos_is_enabled()
+
+    def test_enable_is_idempotent(self, fake_home):
+        with patch.object(autostart, "_command", return_value=["/opt/aw/aw-qt"]):
+            autostart._macos_enable()
+            first = autostart._macos_plist_path().read_bytes()
+            autostart._macos_enable()
+        assert autostart._macos_plist_path().read_bytes() == first
+        assert autostart._macos_is_enabled()
+
+    def test_disable_removes_launch_agent(self, fake_home):
+        autostart._macos_enable()
+        autostart._macos_disable()
+        assert not autostart._macos_plist_path().exists()
+        assert not autostart._macos_is_enabled()
+
+    def test_disable_is_idempotent(self, fake_home):
+        autostart._macos_disable()
+        autostart._macos_disable()
+        assert not autostart._macos_is_enabled()
+
+    def test_no_launchctl_invocation(self, fake_home):
+        """Loading/unloading would duplicate or kill the running instance."""
+        with patch("subprocess.run") as run, patch("subprocess.call") as call, patch(
+            "subprocess.Popen"
+        ) as popen:
+            autostart._macos_enable()
+            autostart._macos_disable()
+        run.assert_not_called()
+        call.assert_not_called()
+        popen.assert_not_called()
+
+
+class TestWindowsBackend:
+    """The registry/filesystem leaves are mocked; this tests the precedence logic."""
+
+    def test_enabled_via_run_key(self):
+        with patch.object(autostart, "_windows_startup_shortcut", return_value=None):
+            with patch.object(
+                autostart, "_windows_run_value", return_value='"C:\\aw\\aw-qt.exe"'
+            ):
+                assert autostart._windows_is_enabled()
+
+    def test_enabled_via_installer_shortcut(self):
+        """Users who ticked the installer checkbox must read as enabled."""
+        shortcut = Path("C:/Startup/ActivityWatch.lnk")
+        with patch.object(
+            autostart, "_windows_startup_shortcut", return_value=shortcut
+        ):
+            with patch.object(
+                autostart, "_windows_run_value", return_value=None
+            ) as run_value:
+                assert autostart._windows_is_enabled()
+            run_value.assert_not_called()
+
+    def test_disabled_when_neither_present(self):
+        with patch.object(autostart, "_windows_startup_shortcut", return_value=None):
+            with patch.object(autostart, "_windows_run_value", return_value=None):
+                assert not autostart._windows_is_enabled()
+
+    def test_enable_writes_run_key(self):
+        with patch.object(autostart, "_windows_startup_shortcut", return_value=None):
+            with patch.object(
+                autostart, "_command", return_value=["C:\\aw\\aw-qt.exe"]
+            ):
+                with patch.object(autostart, "_windows_set_run_value") as set_value:
+                    autostart._windows_enable()
+        set_value.assert_called_once()
+        assert "aw-qt.exe" in set_value.call_args[0][0]
+
+    def test_enable_skips_run_key_when_shortcut_exists(self):
+        """Writing both would start aw-qt twice at login."""
+        shortcut = Path("C:/Startup/ActivityWatch.lnk")
+        with patch.object(
+            autostart, "_windows_startup_shortcut", return_value=shortcut
+        ):
+            with patch.object(autostart, "_windows_set_run_value") as set_value:
+                autostart._windows_enable()
+        set_value.assert_not_called()
+
+    def test_disable_removes_both_locations(self):
+        with patch.object(autostart, "_windows_delete_run_value") as del_value:
+            with patch.object(
+                autostart, "_windows_delete_startup_shortcut"
+            ) as del_shortcut:
+                autostart._windows_disable()
+        del_value.assert_called_once()
+        del_shortcut.assert_called_once()
+
+    def test_disable_is_idempotent(self):
+        """Neither location present: no errors, nothing to remove."""
+        with patch.object(autostart, "_windows_startup_shortcut", return_value=None):
+            with patch.object(autostart, "_windows_run_value", return_value=None):
+                # The winreg-backed helpers are no-ops off Windows
+                autostart._windows_disable()
+                autostart._windows_disable()
+                assert not autostart._windows_is_enabled()
+
+
+class TestCommand:
+    def test_frozen_bundle_uses_executable(self):
+        with patch.object(autostart.sys, "frozen", True, create=True):
+            with patch.object(autostart.sys, "executable", "/Applications/aw-qt"):
+                assert autostart._command() == ["/Applications/aw-qt"]
+
+    def test_prefers_aw_qt_on_path(self):
+        with patch("shutil.which", return_value="/usr/local/bin/aw-qt"):
+            assert autostart._command() == ["/usr/local/bin/aw-qt"]
+
+    def test_falls_back_to_module_invocation(self):
+        with patch("shutil.which", return_value=None):
+            assert autostart._command() == [autostart.sys.executable, "-m", "aw_qt"]

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -169,11 +169,88 @@ class TestLinuxBackend:
         assert "Icon=activitywatch" in contents
         assert "Exec=/opt/aw/aw-qt --flag" in contents
 
-    def test_exec_value_is_quoted(self):
+    def test_simple_arguments_are_not_quoted(self):
+        with patch.object(autostart, "_command", return_value=["/opt/aw/aw-qt", "-v"]):
+            assert autostart._desktop_exec_value() == "/opt/aw/aw-qt -v"
+
+    def test_exec_value_uses_desktop_entry_quoting(self):
+        """Desktop Entry Exec quoting is not POSIX shell quoting."""
         with patch.object(
             autostart, "_command", return_value=["/path with space/aw-qt"]
         ):
-            assert autostart._desktop_exec_value() == "'/path with space/aw-qt'"
+            # Double quotes, not the single quotes shlex.quote() would produce
+            assert autostart._desktop_exec_value() == '"/path with space/aw-qt"'
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            ["/opt/aw/aw-qt"],
+            ["/opt/aw/aw-qt", "--testing"],
+            ["/home/me/My Apps/aw-qt"],
+            ["/opt/a$b/aw-qt", "--flag=a b"],
+            ["/opt/back\\slash/aw-qt"],
+            ["/opt/aw/aw-qt", 'quote"d'],
+            ["/opt/100%/aw-qt"],
+            ["/usr/bin/python3", "-m", "aw_qt"],
+        ],
+    )
+    def test_exec_value_round_trips_through_a_parser(self, command):
+        """The written Exec value must parse back to the exact command."""
+        with patch.object(autostart, "_command", return_value=command):
+            value = autostart._desktop_exec_value()
+        assert parse_desktop_exec(value) == command
+
+
+def parse_desktop_exec(value):
+    """Reference implementation of Desktop Entry Exec parsing.
+
+    Applies the string-value unescaping and then the Exec quoting rules from
+    https://specifications.freedesktop.org/desktop-entry-spec/latest/exec-variables.html
+    """
+    # Desktop entry string values: "\\" denotes a literal backslash
+    unescaped = ""
+    i = 0
+    while i < len(value):
+        if value[i] == "\\" and i + 1 < len(value) and value[i + 1] == "\\":
+            unescaped += "\\"
+            i += 2
+        else:
+            unescaped += value[i]
+            i += 1
+
+    args = []
+    current = ""
+    in_quotes = False
+    started = False
+    i = 0
+    while i < len(unescaped):
+        char = unescaped[i]
+        if in_quotes:
+            if char == "\\" and i + 1 < len(unescaped) and unescaped[i + 1] in '"`$\\':
+                current += unescaped[i + 1]
+                i += 2
+                continue
+            if char == '"':
+                in_quotes = False
+            else:
+                current += char
+        elif char == '"':
+            in_quotes = True
+            started = True
+        elif char == " ":
+            if started:
+                args.append(current)
+            current = ""
+            started = False
+        else:
+            current += char
+            started = True
+        i += 1
+    if started:
+        args.append(current)
+
+    # A literal percent sign is written as "%%"
+    return [arg.replace("%%", "%") for arg in args]
 
 
 class TestMacosBackend:


### PR DESCRIPTION
## Problem

The only OS-level autostart in this repo is `scripts/config-autostart.sh`: Linux-only, run manually via `make install`, and it prints "Platform not supported in script, exiting" everywhere else. So:

- **macOS has no autostart at all.**
- **Windows** only has the installer's opt-in checkbox (`{userstartup}` in `activitywatch-setup.iss`), which cannot be changed afterwards from within the app.
- There is nothing in the UI that tells the user whether ActivityWatch will come back after a reboot.

(Note: `AwQtSettings.autostart_modules` is a different thing — it decides which AW *modules* aw-qt starts once it is already running.)

The practical consequence is silent data loss: a user reboots, aw-qt never comes back, and nothing indicates that recording stopped. This is especially painful for research/study deployments where participants run the Qt bundle unattended for weeks.

## Change

A **"Start at login"** checkable item in the tray menu, backed by a new platform-abstraction module `aw_qt/autostart.py` exposing `is_enabled()`, `enable()`, `disable()` (plus `is_supported()` so the menu item is hidden where no backend exists). Stdlib only, no new dependencies.

| Platform | Mechanism |
|---|---|
| Linux/BSD | `$XDG_CONFIG_HOME/autostart/aw-qt.desktop` (defaults to `~/.config/autostart`) — the same location `scripts/config-autostart.sh` uses, reusing the packaged `resources/aw-qt.desktop` as the template when it can be found (also inside the PyInstaller bundle, where the spec places it) |
| macOS | LaunchAgent plist at `~/Library/LaunchAgents/net.activitywatch.aw-qt.plist` with `RunAtLoad`, written with `plistlib` |
| Windows | `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` via `winreg`, **plus** detection of the installer's Startup-folder shortcut |

### Windows precedence (the interesting bit)

`is_enabled()` checks **both** the `Run` registry value and `%APPDATA%\...\Startup\ActivityWatch.lnk`, the shortcut created by the installer's "Start ActivityWatch when Windows starts" task. Checking only the registry would make the toggle read "off" for everyone who ticked that box, and switching it on would create a *second* autostart entry.

Chosen precedence:
- The Startup shortcut counts as enabled.
- If it is present, `enable()` does **not** also write the `Run` value (that would launch aw-qt twice).
- `disable()` removes both, otherwise the toggle would appear to do nothing for installer users.

The Startup folder is resolved from `Shell Folders\Startup` in the registry (localized/redirected paths), falling back to `%APPDATA%`.

### macOS: no `launchctl`

Deliberately no `launchctl load/unload`:
- `load -w` triggers `RunAtLoad` immediately, starting a duplicate aw-qt that the single-instance lock then kills.
- `unload` would terminate the instance launchd started at login — i.e. quit the app the user just clicked in.

launchd rescans `~/Library/LaunchAgents` at every login, so writing/removing the plist is sufficient and matches login-item semantics (takes effect from the next login). There is a test asserting no subprocess is spawned.

### Robustness

- All filesystem/registry operations are idempotent; enabling when already enabled (or disabling when already disabled) is a no-op and never raises. Files are written atomically (temp file + `os.replace`).
- `is_enabled()` never raises — an unreadable file, missing registry key or unsupported platform is reported as `False` and logged.
- `enable()`/`disable()` raise `AutostartError`, which the tray catches and shows in a `QMessageBox`; the checkbox is then re-synced with the real state, so a failed toggle cannot leave the menu lying. The menu also re-reads the state on `aboutToShow`, so changes made outside aw-qt are picked up.
- Linux `is_enabled()` treats `Hidden=true` / `X-GNOME-Autostart-enabled=false` (what desktop environments write when the user disables an entry in their own UI) as disabled, and `enable()` clears them.

## Testing

- `tests/test_autostart.py`: 39 unit tests covering platform selection, idempotency of enable/disable on all three backends, Windows shortcut-vs-registry precedence, error propagation, and command resolution (frozen bundle / `aw-qt` on PATH / `python -m aw_qt`). The OS layer is mocked and the home directory redirected to a `tmp_path`, so nothing touches the real environment and the suite runs on any platform.
- `make typecheck` passes; `flake8` reports nothing new for the added files; the added files are `black`-clean.
- `make test` and `make test-integration` (under `xvfb-run`) pass.
- Manually smoke-tested the tray menu under Xvfb: the item appears, toggling on writes the `.desktop` file with a correct `Exec=`, toggling off removes it, and the checkbox tracks the real state.

Note that `tests/` is not currently run by `make test` (which only does an import check) and pytest is not a dev dependency, so the new tests follow the existing `tests/test_manager.py` convention rather than changing the CI/dependency setup. Happy to wire pytest into `make test` in a follow-up if that is wanted.
