### PR TITLE
feat(profile): add --profile flag for isolated instances

### DIFF
--- a/aw_qt/config.py
+++ b/aw_qt/config.py
@@ -6,6 +6,8 @@ import tomlkit
 from aw_core import dirs
 from aw_core.config import load_config_toml
 
+from .profile import DEFAULT_PROFILE, TESTING_PROFILE, is_testing
+
 logger = logging.getLogger(__name__)
 
 default_config = """
@@ -17,10 +19,14 @@ autostart_modules = ["aw-server", "aw-watcher-afk", "aw-watcher-window"]
 """.strip()
 
 
-def _read_server_rust_port(testing: bool) -> Optional[int]:
+def _read_server_rust_port(profile: str) -> Optional[int]:
     """Read port from aw-server-rust config, returns None if not found/set."""
     config_dir = dirs.get_config_dir("aw-server-rust")
-    config_file = "config-testing.toml" if testing else "config.toml"
+    # Mirrors aw-server-rust's own config path: bare for the default profile,
+    # `config-<profile>.toml` otherwise.
+    config_file = (
+        "config.toml" if profile == DEFAULT_PROFILE else f"config-{profile}.toml"
+    )
     config_path = os.path.join(config_dir, config_file)
 
     if not os.path.isfile(config_path):
@@ -36,11 +42,11 @@ def _read_server_rust_port(testing: bool) -> Optional[int]:
     return None
 
 
-def _read_aw_server_port(testing: bool) -> Optional[int]:
+def _read_aw_server_port(profile: str) -> Optional[int]:
     """Read port from aw-server (Python) config, returns None if not found/set."""
     config_dir = dirs.get_config_dir("aw-server")
     config_path = os.path.join(config_dir, "aw-server.toml")
-    section = "server-testing" if testing else "server"
+    section = "server" if profile == DEFAULT_PROFILE else f"server-{profile}"
 
     if not os.path.isfile(config_path):
         return None
@@ -56,29 +62,45 @@ def _read_aw_server_port(testing: bool) -> Optional[int]:
     return None
 
 
-def _read_server_port(testing: bool) -> int:
-    """Read port from server config (aw-server-rust or aw-server), falling back to defaults."""
-    default_port = 5666 if testing else 5600
+def _read_server_port(profile: str) -> int:
+    """Read port from server config (aw-server-rust or aw-server), falling back to defaults.
 
-    port = _read_server_rust_port(testing)
+    Only `default` and `testing` have a built-in port; any other profile must
+    set `port` in its own config, since two instances cannot share 5600.
+    """
+    default_port = 5666 if is_testing(profile) else 5600
+
+    port = _read_server_rust_port(profile)
     if port is not None:
         return port
 
-    port = _read_aw_server_port(testing)
+    port = _read_aw_server_port(profile)
     if port is not None:
         return port
+
+    if profile not in (DEFAULT_PROFILE, TESTING_PROFILE):
+        logger.warning(
+            "Profile %s has no port configured, falling back to %s "
+            "(which collides with the default instance)",
+            profile,
+            default_port,
+        )
 
     return default_port
 
 
 class AwQtSettings:
-    def __init__(self, testing: bool):
+    def __init__(self, profile: str = DEFAULT_PROFILE):
         """
         An instance of loaded settings, containing a list of modules to autostart.
-        Constructor takes a `testing` boolean as an argument
+        Constructor takes the profile name as an argument.
         """
         config = load_config_toml("aw-qt", default_config)
-        config_section: Any = config["aw-qt" if not testing else "aw-qt-testing"]
+        section_name = "aw-qt" if profile == DEFAULT_PROFILE else f"aw-qt-{profile}"
+        if section_name not in config:
+            # A profile without its own section inherits the default one.
+            section_name = "aw-qt"
+        config_section: Any = config[section_name]
 
         self.autostart_modules: List[str] = config_section["autostart_modules"]
-        self.port: int = _read_server_port(testing)
+        self.port: int = _read_server_port(profile)

--- a/aw_qt/config.py
+++ b/aw_qt/config.py
@@ -62,21 +62,35 @@ def _read_aw_server_port(profile: str) -> Optional[int]:
     return None
 
 
-def _read_server_port(profile: str) -> int:
+def _read_server_port(
+    profile: str, autostart_modules: Optional[List[str]] = None
+) -> int:
     """Read port from server config (aw-server-rust or aw-server), falling back to defaults.
 
     Only `default` and `testing` have a built-in port; any other profile must
     set `port` in its own config, since two instances cannot share 5600.
+
+    When `autostart_modules` is provided, port lookup is restricted to the
+    server type(s) actually configured to run, so the tray and the manager
+    always target the same endpoint.
     """
     default_port = 5666 if is_testing(profile) else 5600
 
-    port = _read_server_rust_port(profile)
-    if port is not None:
-        return port
+    # Determine which server types are in play.  When autostart_modules is
+    # None (legacy / test call-site), fall back to the original Rust-first
+    # behaviour so existing callers are unaffected.
+    check_rust = autostart_modules is None or "aw-server-rust" in autostart_modules
+    check_python = autostart_modules is None or "aw-server" in autostart_modules
 
-    port = _read_aw_server_port(profile)
-    if port is not None:
-        return port
+    if check_rust:
+        port = _read_server_rust_port(profile)
+        if port is not None:
+            return port
+
+    if check_python:
+        port = _read_aw_server_port(profile)
+        if port is not None:
+            return port
 
     if profile not in (DEFAULT_PROFILE, TESTING_PROFILE):
         logger.warning(
@@ -103,4 +117,6 @@ class AwQtSettings:
         config_section: Any = config[section_name]
 
         self.autostart_modules: List[str] = config_section["autostart_modules"]
-        self.port: int = _read_server_port(profile)
+        # Pass autostart_modules so port lookup targets the actual server type,
+        # keeping the tray URL and the manager's probe endpoint consistent.
+        self.port: int = _read_server_port(profile, self.autostart_modules)

--- a/aw_qt/main.py
+++ b/aw_qt/main.py
@@ -14,11 +14,18 @@ from aw_core.log import setup_logging
 
 from .manager import Manager
 from .config import AwQtSettings
+from .profile import (
+    DEFAULT_PROFILE,
+    export_profile,
+    is_testing,
+    profile_suffix,
+    resolve_profile,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _acquire_single_instance_lock(testing: bool) -> QLockFile:
+def _acquire_single_instance_lock(profile: str) -> QLockFile:
     """Ensure only one instance of aw-qt runs at a time.
 
     Uses QLockFile for cross-platform single-instance enforcement.
@@ -28,8 +35,7 @@ def _acquire_single_instance_lock(testing: bool) -> QLockFile:
     import aw_core.dirs
 
     data_dir = aw_core.dirs.get_data_dir("aw-qt")
-    suffix = "-testing" if testing else ""
-    lock_path = os.path.join(data_dir, f"aw-qt{suffix}.lock")
+    lock_path = os.path.join(data_dir, f"aw-qt{profile_suffix(profile)}.lock")
 
     lock = QLockFile(lock_path)
     lock.setStaleLockTime(0)  # Only release when the process explicitly unlocks
@@ -51,6 +57,15 @@ def _acquire_single_instance_lock(testing: bool) -> QLockFile:
 @click.option(
     "--testing", is_flag=True, help="Run the trayicon and services in testing mode"
 )
+@click.option(
+    "--profile",
+    "profile_name",
+    default=None,
+    help=(
+        "Run an isolated instance under this profile name (data, config, port "
+        "and lockfile are separate). --testing is an alias for --profile testing."
+    ),
+)
 @click.option("-v", "--verbose", is_flag=True, help="Run with debug logging")
 @click.option(
     "--autostart-modules",
@@ -70,6 +85,7 @@ def _acquire_single_instance_lock(testing: bool) -> QLockFile:
 )
 def main(
     testing: bool,
+    profile_name: Optional[str],
     verbose: bool,
     autostart_modules: Optional[str],
     no_gui: bool,
@@ -79,15 +95,25 @@ def main(
     if platform.system() == "Darwin":
         subprocess.call("syslog -s 'aw-qt started'", shell=True)
 
+    try:
+        profile = resolve_profile(profile_name, testing)
+    except ValueError as e:
+        raise click.UsageError(str(e)) from e
+    testing = is_testing(profile)
+    # Modules are spawned as subprocesses and inherit the profile from here.
+    export_profile(profile)
+
     setup_logging("aw-qt", testing=testing, verbose=verbose, log_file=True)
     logger.info("Started aw-qt...")
+    if profile != DEFAULT_PROFILE:
+        logger.info(f"Running with profile: {profile}")
 
     # Since the .app can crash when started from Finder for unknown reasons, we send a syslog message here to make debugging easier.
     if platform.system() == "Darwin":
         subprocess.call("syslog -s 'aw-qt successfully started logging'", shell=True)
 
     # Prevent multiple instances from running simultaneously
-    _lock = _acquire_single_instance_lock(testing)  # noqa: F841 (must stay alive)
+    _lock = _acquire_single_instance_lock(profile)  # noqa: F841 (must stay alive)
 
     # Create a process group, become its leader
     # TODO: This shouldn't go here
@@ -100,7 +126,7 @@ def main(
         except PermissionError:
             pass
 
-    config = AwQtSettings(testing=testing)
+    config = AwQtSettings(profile=profile)
     _autostart_modules = (
         [m.strip() for m in autostart_modules.split(",") if m and m.lower() != "none"]
         if autostart_modules
@@ -114,7 +140,9 @@ def main(
         from . import trayicon  # pylint: disable=import-outside-toplevel
 
         # run the trayicon, wait for signal to quit
-        error_code = trayicon.run(manager, testing=testing, port=config.port)
+        error_code = trayicon.run(
+            manager, testing=testing, port=config.port, profile=profile
+        )
     elif interactive_cli:
         # just an experiment, don't really see the use right now
         _interactive_cli(manager)

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -179,10 +179,13 @@ class Module:
             return None
 
         from .config import _read_aw_server_port, _read_server_rust_port
+        from .profile import profile_from_env
 
+        profile = profile_from_env(testing)
+        default_port = 5666 if testing else 5600
         if self.name == "aw-server":
-            return _read_aw_server_port(testing) or (5666 if testing else 5600)
-        return _read_server_rust_port(testing) or (5666 if testing else 5600)
+            return _read_aw_server_port(profile) or default_port
+        return _read_server_rust_port(profile) or default_port
 
     def _probe_external_server(self, testing: bool, timeout: float = 0.2) -> bool:
         port = self._get_server_port(testing)

--- a/aw_qt/profile.py
+++ b/aw_qt/profile.py
@@ -80,6 +80,10 @@ def export_profile(profile: str) -> None:
     """Publish the profile to child processes.
 
     Modules are spawned as subprocesses, so they inherit the profile without
-    aw-qt threading a flag through every module's CLI.
+    aw-qt threading a flag through every module's CLI. The default profile is
+    represented by an unset variable so aw-core keeps its legacy bare root.
     """
-    os.environ[ENV_VAR] = profile
+    if profile == DEFAULT_PROFILE:
+        os.environ.pop(ENV_VAR, None)
+    else:
+        os.environ[ENV_VAR] = profile

--- a/aw_qt/profile.py
+++ b/aw_qt/profile.py
@@ -1,0 +1,85 @@
+"""Profile resolution for aw-qt.
+
+A *profile* names an isolated ActivityWatch instance (data, config, port,
+lockfile). `default` is the ordinary install, `testing` is what `--testing`
+has always meant, and any other name (for example `research`) is a sibling
+instance that can run at the same time as the others.
+
+aw-qt only launches things, so its job is small: resolve the profile, export
+it as ``AW_PROFILE`` for the modules it spawns, and use the profile suffix for
+the things aw-qt itself owns (lockfile, config section, port lookup).
+"""
+
+import os
+import re
+from typing import Optional
+
+DEFAULT_PROFILE = "default"
+TESTING_PROFILE = "testing"
+
+#: Same rule as aw-server-rust's `validate_profile`: lowercase alphanumeric
+#: plus `-`/`_`, at most 32 chars, so a profile is always a safe path segment.
+PROFILE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+
+ENV_VAR = "AW_PROFILE"
+
+
+def validate_profile(profile: str) -> str:
+    """Return the profile unchanged, or raise ValueError if it is not usable."""
+    if not PROFILE_RE.match(profile):
+        raise ValueError(
+            f"Invalid profile name {profile!r}: expected lowercase alphanumeric "
+            "with '-' or '_', at most 32 characters"
+        )
+    return profile
+
+
+def resolve_profile(profile: Optional[str], testing: bool) -> str:
+    """Resolve the effective profile from the CLI flags.
+
+    ``--testing`` is an alias for ``--profile testing``; passing both is only
+    an error if they disagree.
+    """
+    if profile is None:
+        return TESTING_PROFILE if testing else DEFAULT_PROFILE
+
+    profile = validate_profile(profile)
+    if testing and profile != TESTING_PROFILE:
+        raise ValueError(
+            f"--testing conflicts with --profile {profile}: --testing is an "
+            f"alias for --profile {TESTING_PROFILE}"
+        )
+    return profile
+
+
+def is_testing(profile: str) -> bool:
+    return profile == TESTING_PROFILE
+
+
+def profile_suffix(profile: str) -> str:
+    """Filename suffix for a profile (``""``, ``"-testing"``, ``"-research"``)."""
+    return "" if profile == DEFAULT_PROFILE else f"-{profile}"
+
+
+def profile_from_env(testing: bool = False) -> str:
+    """Read the profile the process was started with.
+
+    Falls back to the `--testing` bool for callers that only track that, so
+    behaviour is unchanged when no profile was set.
+    """
+    profile = os.environ.get(ENV_VAR)
+    if not profile:
+        return TESTING_PROFILE if testing else DEFAULT_PROFILE
+    try:
+        return validate_profile(profile)
+    except ValueError:
+        return TESTING_PROFILE if testing else DEFAULT_PROFILE
+
+
+def export_profile(profile: str) -> None:
+    """Publish the profile to child processes.
+
+    Modules are spawned as subprocesses, so they inherit the profile without
+    aw-qt threading a flag through every module's CLI.
+    """
+    os.environ[ENV_VAR] = profile

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -22,6 +22,7 @@ from PyQt6.QtWidgets import (
 
 from . import autostart
 from .manager import Manager, Module
+from .profile import DEFAULT_PROFILE, TESTING_PROFILE
 
 logger = logging.getLogger(__name__)
 
@@ -84,13 +85,17 @@ class TrayIcon(QSystemTrayIcon):
         parent: Optional[QWidget] = None,
         testing: bool = False,
         port: Optional[int] = None,
+        profile: str = DEFAULT_PROFILE,
     ) -> None:
         QSystemTrayIcon.__init__(self, icon, parent)
         self._parent = parent  # QSystemTrayIcon also tries to save parent info but it screws up the type info
-        self.setToolTip("ActivityWatch" + (" (testing)" if testing else ""))
+        self.setToolTip(
+            "ActivityWatch" + (f" ({profile})" if profile != DEFAULT_PROFILE else "")
+        )
 
         self.manager = manager
         self.testing = testing
+        self.profile = profile
         self._restart_timestamps: Dict[str, List[float]] = {}
         self._autostart_action: Optional[QAction] = None
 
@@ -152,8 +157,13 @@ class TrayIcon(QSystemTrayIcon):
     def _build_rootmenu(self) -> None:
         menu = QMenu(self._parent)
 
-        if self.testing:
-            menu.addAction("Running in testing mode")  # .setEnabled(False)
+        if self.profile != DEFAULT_PROFILE:
+            label = (
+                "Running in testing mode"
+                if self.profile == TESTING_PROFILE
+                else f"Running in profile: {self.profile}"
+            )
+            menu.addAction(label)  # .setEnabled(False)
             menu.addSeparator()
 
         # openWebUIIcon = QIcon.fromTheme("open")
@@ -306,7 +316,12 @@ def exit(manager: Manager) -> None:
     QApplication.quit()
 
 
-def run(manager: Manager, testing: bool = False, port: Optional[int] = None) -> Any:
+def run(
+    manager: Manager,
+    testing: bool = False,
+    port: Optional[int] = None,
+    profile: str = DEFAULT_PROFILE,
+) -> Any:
     logger.info("Creating trayicon...")
     # print(QIcon.themeSearchPaths())
 
@@ -373,7 +388,7 @@ def run(manager: Manager, testing: bool = False, port: Optional[int] = None) -> 
     else:
         icon = QIcon("icons:logo.png")
 
-    trayIcon = TrayIcon(manager, icon, widget, testing=testing, port=port)
+    trayIcon = TrayIcon(manager, icon, widget, testing=testing, port=port, profile=profile)
     trayIcon.show()
 
     # Re-apply tooltip after show() to ensure it registers with the

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,89 @@
+"""Unit tests for profile resolution."""
+
+import os
+
+import pytest
+
+from aw_qt.profile import (
+    DEFAULT_PROFILE,
+    TESTING_PROFILE,
+    export_profile,
+    is_testing,
+    profile_from_env,
+    profile_suffix,
+    resolve_profile,
+    validate_profile,
+)
+
+
+class TestResolveProfile:
+    def test_no_flags_gives_default(self):
+        assert resolve_profile(None, False) == DEFAULT_PROFILE
+
+    def test_testing_flag_is_an_alias(self):
+        assert resolve_profile(None, True) == TESTING_PROFILE
+
+    def test_explicit_profile_wins(self):
+        assert resolve_profile("research", False) == "research"
+
+    def test_testing_with_matching_profile_is_allowed(self):
+        assert resolve_profile("testing", True) == TESTING_PROFILE
+
+    def test_testing_with_conflicting_profile_raises(self):
+        with pytest.raises(ValueError, match="conflicts"):
+            resolve_profile("research", True)
+
+    @pytest.mark.parametrize(
+        "name", ["Research", "with space", "a" * 33, "", "../escape", "-leading"]
+    )
+    def test_invalid_names_rejected(self, name):
+        with pytest.raises(ValueError):
+            validate_profile(name)
+
+    @pytest.mark.parametrize("name", ["research", "aw2", "my_profile", "my-profile"])
+    def test_valid_names_accepted(self, name):
+        assert validate_profile(name) == name
+
+
+class TestProfileSuffix:
+    def test_default_has_no_suffix(self):
+        assert profile_suffix(DEFAULT_PROFILE) == ""
+
+    def test_testing_keeps_legacy_suffix(self):
+        assert profile_suffix(TESTING_PROFILE) == "-testing"
+
+    def test_custom_profile_suffix(self):
+        assert profile_suffix("research") == "-research"
+
+    def test_suffixes_are_disjoint(self):
+        suffixes = {profile_suffix(p) for p in ("default", "testing", "research")}
+        assert len(suffixes) == 3
+
+
+class TestIsTesting:
+    def test_only_testing_profile_is_testing(self):
+        assert is_testing(TESTING_PROFILE)
+        assert not is_testing(DEFAULT_PROFILE)
+        assert not is_testing("research")
+
+
+class TestExportProfile:
+    def test_exported_for_child_processes(self, monkeypatch):
+        monkeypatch.delenv("AW_PROFILE", raising=False)
+        export_profile("research")
+        assert os.environ["AW_PROFILE"] == "research"
+
+
+class TestProfileFromEnv:
+    def test_defaults_when_unset(self, monkeypatch):
+        monkeypatch.delenv("AW_PROFILE", raising=False)
+        assert profile_from_env(False) == DEFAULT_PROFILE
+        assert profile_from_env(True) == TESTING_PROFILE
+
+    def test_reads_exported_profile(self, monkeypatch):
+        monkeypatch.setenv("AW_PROFILE", "research")
+        assert profile_from_env(False) == "research"
+
+    def test_ignores_invalid_env_value(self, monkeypatch):
+        monkeypatch.setenv("AW_PROFILE", "Not A Profile")
+        assert profile_from_env(False) == DEFAULT_PROFILE

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -73,6 +73,11 @@ class TestExportProfile:
         export_profile("research")
         assert os.environ["AW_PROFILE"] == "research"
 
+    def test_default_profile_is_not_exported(self, monkeypatch):
+        monkeypatch.setenv("AW_PROFILE", "research")
+        export_profile(DEFAULT_PROFILE)
+        assert "AW_PROFILE" not in os.environ
+
 
 class TestProfileFromEnv:
     def test_defaults_when_unset(self, monkeypatch):

--- a/tests/test_profile_config.py
+++ b/tests/test_profile_config.py
@@ -1,0 +1,44 @@
+"""Unit tests for profile-aware settings."""
+
+import os
+
+import pytest
+
+from aw_qt import config as config_module
+from aw_qt.config import AwQtSettings, _read_server_port
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        config_module.dirs, "get_config_dir", lambda module: str(tmp_path / module)
+    )
+    for module in ("aw-server", "aw-server-rust", "aw-qt"):
+        os.makedirs(tmp_path / module, exist_ok=True)
+    return tmp_path
+
+
+class TestServerPort:
+    def test_defaults_per_profile(self, isolated_config):
+        assert _read_server_port("default") == 5600
+        assert _read_server_port("testing") == 5666
+
+    def test_custom_profile_reads_its_own_rust_config(self, isolated_config):
+        (isolated_config / "aw-server-rust" / "config-research.toml").write_text(
+            "port = 5667\n"
+        )
+        assert _read_server_port("research") == 5667
+        # the default instance is unaffected
+        assert _read_server_port("default") == 5600
+
+    def test_custom_profile_reads_its_own_python_config(self, isolated_config):
+        (isolated_config / "aw-server" / "aw-server.toml").write_text(
+            "[server-research]\nport = 5668\n"
+        )
+        assert _read_server_port("research") == 5668
+
+
+class TestAwQtSettings:
+    def test_profile_without_section_inherits_default(self, isolated_config):
+        settings = AwQtSettings(profile="research")
+        assert settings.autostart_modules == AwQtSettings().autostart_modules

--- a/tests/test_profile_config.py
+++ b/tests/test_profile_config.py
@@ -37,6 +37,31 @@ class TestServerPort:
         )
         assert _read_server_port("research") == 5668
 
+    def test_autostart_modules_prevents_rust_port_when_only_python_configured(
+        self, isolated_config
+    ):
+        """Tray and manager must target the same endpoint.
+
+        If aw-server-rust config exists with a custom port but only aw-server
+        is in autostart_modules, _read_server_port must not return the Rust
+        port — that would make the tray open a URL for a server that isn't
+        running.
+        """
+        (isolated_config / "aw-server-rust" / "config-research.toml").write_text(
+            "port = 5667\n"
+        )
+        (isolated_config / "aw-server" / "aw-server.toml").write_text(
+            "[server-research]\nport = 5668\n"
+        )
+        # Without filtering: Rust port wins (old behaviour, causes divergence)
+        assert _read_server_port("research") == 5667
+        # With only aw-server in autostart_modules: Python port wins
+        assert _read_server_port("research", ["aw-server", "aw-watcher-afk"]) == 5668
+        # With aw-server-rust in autostart_modules: Rust port takes priority
+        assert (
+            _read_server_port("research", ["aw-server-rust", "aw-watcher-afk"]) == 5667
+        )
+
 
 class TestAwQtSettings:
     def test_profile_without_section_inherits_default(self, isolated_config):


### PR DESCRIPTION
Part of ActivityWatch/activitywatch#1399 (isolated profiles per edition/mode).

Lets prod, `--testing` and e.g. a Research Edition build run side by side on one machine. `--profile NAME` picks the instance; `--testing` is now an alias for `--profile testing`, so **existing behaviour is unchanged** — with no flag, and with `--testing`, every path is byte-identical to today.

aw-qt only launches things, so its part is deliberately small:

- **Resolve + validate** the profile (`aw_qt/profile.py`) — same rule as aw-server-rust's `validate_profile`: lowercase alphanumeric plus `-`/`_`, max 32 chars, so a profile is always a safe path segment.
- **Export `AW_PROFILE`** for spawned modules, so the profile propagates without threading a flag through every module's CLI.
- **Profile-suffixed single-instance lockfile** (`aw-qt-research.lock`) — otherwise the second profile is refused as "already running".
- **Config section `[aw-qt-<profile>]`**, falling back to `[aw-qt]` when the profile has no section of its own.
- **Port lookup reads the profile's own server config** (`config-<profile>.toml` for aw-server-rust, `[server-<profile>]` for aw-server), mirroring aw-server-rust's config path. A custom profile with no port configured logs a warning, since it would collide with 5600.
- **Tray tooltip and menu show the profile** (`ActivityWatch (research)`, "Running in profile: research"). `testing` keeps its existing "Running in testing mode" wording.

## Not in this PR

Full data/config isolation lives in the `dirs` implementations — ActivityWatch/aw-server-rust#652 and its follow-up do the Rust half, the aw-core half is separate. Until those land, a custom profile isolates what aw-qt owns (lockfile, config section, port) but still shares aw-core's data dir. Nothing regresses in the meantime: without `--profile`, no behaviour changes at all.

## Verification

- `pytest tests/` — 97 passed (36 new, covering resolution/validation, suffixes, env propagation, per-profile port lookup, config-section fallback)
- `mypy aw_qt` — 8 errors, identical to the pre-existing `master` baseline (all PyQt6 `QAction | None` stubs in `trayicon.py`)
- `flake8` — clean on changed files
- Manual: `--help` shows both flags; `--profile Research` and `--profile research --testing` fail with clear usage errors