### PR TITLE
feat(trayicon): detect database-locked state and show recovery notification

### DIFF
--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -416,7 +416,7 @@ class Manager:
         else:
             logger.error(f"Manager tried to stop nonexistent module {module_name}")
 
-    def get_db_locked_modules(self) -> List[Module]:
+    def get_db_locked_modules(self, recent_lines: int = 200) -> List[Module]:
         """Return server modules whose recent logs indicate a database-locked error."""
         server_names = {"aw-server", "aw-server-rust"}
         return [
@@ -424,7 +424,7 @@ class Manager:
             for m in self.modules
             if m.name in server_names
             and m.is_alive()
-            and m.has_db_locked_error(self.testing)
+            and m.has_db_locked_error(self.testing, recent_lines=recent_lines)
         ]
 
     def stop_all(self) -> None:

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -329,6 +329,22 @@ class Module:
         else:
             return "No log file found"
 
+    def has_db_locked_error(self, testing: bool, recent_lines: int = 200) -> bool:
+        """Check if recent logs contain SQLite 'database is locked' errors."""
+        log_path = aw_core.log.get_latest_log_file(self.name, testing)
+        if not log_path:
+            return False
+        try:
+            with open(log_path) as f:
+                lines = f.readlines()
+            tail = lines[-recent_lines:] if len(lines) > recent_lines else lines
+            return any(
+                "database is locked" in line.lower() or "database locked" in line.lower()
+                for line in tail
+            )
+        except OSError:
+            return False
+
 
 class Manager:
     def __init__(self, testing: bool = False) -> None:
@@ -399,6 +415,17 @@ class Manager:
                 break
         else:
             logger.error(f"Manager tried to stop nonexistent module {module_name}")
+
+    def get_db_locked_modules(self) -> List[Module]:
+        """Return server modules whose recent logs indicate a database-locked error."""
+        server_names = {"aw-server", "aw-server-rust"}
+        return [
+            m
+            for m in self.modules
+            if m.name in server_names
+            and m.is_alive()
+            and m.has_db_locked_error(self.testing)
+        ]
 
     def stop_all(self) -> None:
         for module in filter(lambda m: m.is_alive(), self.modules):

--- a/aw_qt/manager.py
+++ b/aw_qt/manager.py
@@ -5,6 +5,7 @@ import subprocess
 import platform
 import urllib.error
 import urllib.request
+from collections import deque
 from pathlib import Path
 from glob import glob
 from time import monotonic, sleep
@@ -336,8 +337,7 @@ class Module:
             return False
         try:
             with open(log_path) as f:
-                lines = f.readlines()
-            tail = lines[-recent_lines:] if len(lines) > recent_lines else lines
+                tail = list(deque(f, maxlen=recent_lines))
             return any(
                 "database is locked" in line.lower() or "database locked" in line.lower()
                 for line in tail

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -93,6 +93,7 @@ class TrayIcon(QSystemTrayIcon):
         self.testing = testing
         self._restart_timestamps: Dict[str, List[float]] = {}
         self._autostart_action: Optional[QAction] = None
+        self._db_locked_notified: set = set()  # modules already shown db-locked notification
 
         if port is None:
             port = 5666 if testing else 5600
@@ -171,6 +172,9 @@ class TrayIcon(QSystemTrayIcon):
         )
         menu.addAction(
             "Open config folder", lambda: open_dir(aw_core.dirs.get_config_dir(None))
+        )
+        menu.addAction(
+            "Open data folder", lambda: open_dir(aw_core.dirs.get_data_dir(None))
         )
 
         if autostart.is_supported():
@@ -266,6 +270,33 @@ class TrayIcon(QSystemTrayIcon):
             QtCore.QTimer.singleShot(5000, check_module_status)
 
         QtCore.QTimer.singleShot(5000, check_module_status)
+
+        def check_db_locked() -> None:
+            locked = self.manager.get_db_locked_modules()
+            locked_names = {m.name for m in locked}
+
+            # Show notification for newly-detected locked modules
+            for module in locked:
+                if module.name not in self._db_locked_notified:
+                    data_dir = aw_core.dirs.get_data_dir(module.name)
+                    self.showMessage(
+                        "ActivityWatch — Database Locked",
+                        f"The {module.name} database is locked — the web UI may show errors.\n\n"
+                        f"To export your data without the UI, copy the .db files from:\n"
+                        f"{data_dir}\n\n"
+                        f"Or run:  sqlite3 \"{data_dir}/peewee-sqlite.v2.db\" "
+                        f'.backup "{data_dir}/backup.db"',
+                        QSystemTrayIcon.MessageIcon.Warning,
+                        15000,
+                    )
+                    self._db_locked_notified.add(module.name)
+
+            # Clear notifications for modules that are no longer locked
+            self._db_locked_notified -= self._db_locked_notified - locked_names
+
+            QtCore.QTimer.singleShot(30000, check_db_locked)
+
+        QtCore.QTimer.singleShot(30000, check_db_locked)
 
     def _build_modulemenu(self, moduleMenu: QMenu) -> None:
         moduleMenu.clear()

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -291,8 +291,12 @@ class TrayIcon(QSystemTrayIcon):
                     )
                     self._db_locked_notified.add(module.name)
 
-            # Clear notifications for modules that are no longer locked
-            self._db_locked_notified -= self._db_locked_notified - locked_names
+            # Clear notifications using a shorter window so that historical lock
+            # messages (from a now-recovered server) don't keep the module marked
+            # as locked and suppress notification of a subsequent new lock event.
+            recently_locked = self.manager.get_db_locked_modules(recent_lines=20)
+            recently_locked_names = {m.name for m in recently_locked}
+            self._db_locked_notified -= self._db_locked_notified - recently_locked_names
 
             QtCore.QTimer.singleShot(30000, check_db_locked)
 

--- a/aw_qt/trayicon.py
+++ b/aw_qt/trayicon.py
@@ -291,12 +291,12 @@ class TrayIcon(QSystemTrayIcon):
                     )
                     self._db_locked_notified.add(module.name)
 
-            # Clear notifications using a shorter window so that historical lock
-            # messages (from a now-recovered server) don't keep the module marked
-            # as locked and suppress notification of a subsequent new lock event.
-            recently_locked = self.manager.get_db_locked_modules(recent_lines=20)
-            recently_locked_names = {m.name for m in recently_locked}
-            self._db_locked_notified -= self._db_locked_notified - recently_locked_names
+            # Clear notification state for modules no longer seen in the detection
+            # window.  Using the same 200-line window for both detection and clearing
+            # prevents a "dead zone" (lines 20-199) where the short window clears the
+            # notified set while the long window still reports the module as locked,
+            # which would cause a new notification to fire every 30-second poll.
+            self._db_locked_notified &= locked_names
 
             QtCore.QTimer.singleShot(30000, check_db_locked)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -342,3 +342,54 @@ class TestMacOSSystemPathDiscovery:
         assert "/opt/homebrew/bin" not in searched_paths, (
             "Homebrew path should NOT be added on Linux"
         )
+
+
+class TestDbLockedDetection:
+    """Tests for database-locked error detection in module logs."""
+
+    def test_has_db_locked_error_returns_false_when_no_log(self, module):
+        """Returns False when no log file exists."""
+        with patch("aw_core.log.get_latest_log_file", return_value=None):
+            assert not module.has_db_locked_error(testing=True)
+
+    def test_has_db_locked_error_detects_locked_phrase(self, module, tmp_path):
+        """Returns True when log contains 'database is locked'."""
+        log_file = tmp_path / "aw-test.log"
+        log_file.write_text(
+            "2026-01-01 INFO starting\n"
+            "2026-01-01 ERROR database is locked\n"
+        )
+        with patch("aw_core.log.get_latest_log_file", return_value=str(log_file)):
+            assert module.has_db_locked_error(testing=True)
+
+    def test_has_db_locked_error_returns_false_for_clean_log(self, module, tmp_path):
+        """Returns False when log has no lock errors."""
+        log_file = tmp_path / "aw-test.log"
+        log_file.write_text("2026-01-01 INFO everything is fine\n")
+        with patch("aw_core.log.get_latest_log_file", return_value=str(log_file)):
+            assert not module.has_db_locked_error(testing=True)
+
+    def test_get_db_locked_modules_filters_non_server(self):
+        """Only aw-server and aw-server-rust modules are checked."""
+        from aw_qt.manager import Manager
+
+        mgr = Manager.__new__(Manager)
+        mgr.testing = False
+
+        watcher = Module("aw-watcher-window", Path("/usr/bin/true"), "system")
+        watcher.started = True
+        server = Module("aw-server", Path("/usr/bin/true"), "system")
+        server.started = True
+
+        mgr.modules = [watcher, server]
+
+        with (
+            patch.object(watcher, "is_alive", return_value=True),
+            patch.object(watcher, "has_db_locked_error", return_value=True),
+            patch.object(server, "is_alive", return_value=True),
+            patch.object(server, "has_db_locked_error", return_value=True),
+        ):
+            locked = mgr.get_db_locked_modules()
+
+        assert server in locked
+        assert watcher not in locked

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -393,3 +393,37 @@ class TestDbLockedDetection:
 
         assert server in locked
         assert watcher not in locked
+
+    def test_get_db_locked_modules_passes_recent_lines(self):
+        """get_db_locked_modules forwards recent_lines to has_db_locked_error."""
+        from aw_qt.manager import Manager
+
+        mgr = Manager.__new__(Manager)
+        mgr.testing = False
+
+        server = Module("aw-server", Path("/usr/bin/true"), "system")
+        server.started = True
+        mgr.modules = [server]
+
+        with (
+            patch.object(server, "is_alive", return_value=True),
+            patch.object(server, "has_db_locked_error", return_value=True) as mock_check,
+        ):
+            mgr.get_db_locked_modules(recent_lines=20)
+
+        mock_check.assert_called_once_with(False, recent_lines=20)
+
+    def test_has_db_locked_error_only_checks_tail(self, module, tmp_path):
+        """Only the last recent_lines lines are checked — old messages outside the
+        window do not trigger detection, simulating a recovered server."""
+        log_file = tmp_path / "aw-test.log"
+        # 206 lines total: lock error at index 5 (old), 200 clean lines after
+        lines = ["2026-01-01 INFO line\n"] * 205
+        lines.insert(5, "2026-01-01 ERROR database is locked\n")
+        log_file.write_text("".join(lines))
+
+        with patch("aw_core.log.get_latest_log_file", return_value=str(log_file)):
+            # 200-line window: lock message at line 5 of 211 total is outside tail
+            assert not module.has_db_locked_error(testing=True, recent_lines=200)
+            # 211-line window (whole file): message is included
+            assert module.has_db_locked_error(testing=True, recent_lines=211)


### PR DESCRIPTION
## Summary

- Adds `Module.has_db_locked_error()` to detect SQLite 'database is locked' in recent server logs
- Adds `Manager.get_db_locked_modules()` to surface which server modules are locked
- Shows a system tray notification with the data directory path and a `sqlite3` backup command when a locked state is detected (once per lock event, no spam)
- Adds **Open data folder** to the tray menu alongside the existing log/config folder items

## Motivation

Users hit a circular failure: a third-party watcher (e.g. aw-watcher-utilization) can grow the SQLite database until it locks, which then causes the web UI to 500-loop — making the built-in export page inaccessible. The tray notification gives an escape hatch when the only path to recovery is bypassing the UI entirely.

Reported in: ActivityWatch/activitywatch#1394

## Test plan

- [ ] New unit tests in `tests/test_manager.py` cover the log-parsing detection and server-name filtering
- [ ] Manual: simulate a locked DB by adding 'database is locked' to the aw-server log — tray notification appears within 30 s
- [ ] Manual: notification does not repeat on subsequent polls once initially shown
- [ ] CI passing