### PR TITLE
feat(autostart): add autostart_on_first_run config option

### DIFF
--- a/aw_qt/autostart.py
+++ b/aw_qt/autostart.py
@@ -533,3 +533,34 @@ def disable() -> None:
     except Exception as e:
         raise AutostartError(f"Could not disable autostart: {e}") from e
     logger.info("Disabled autostart")
+
+
+FIRST_RUN_MARKER = "autostart-first-run"
+
+
+def ensure_enabled_on_first_run() -> None:
+    """Enable start-at-login once, on the first launch that sees the setting.
+
+    Used by builds where autostart should be on by default (e.g. the Research
+    Edition, where participants' machines must survive reboots without setup
+    steps). A marker file in the aw-qt data dir records that enabling
+    succeeded, so a user who later unchecks "Start at login" is never
+    overridden. On failure no marker is written, and the next launch retries.
+    """
+    if not is_supported():
+        logger.debug("Autostart not supported on this platform; skipping first-run enable")
+        return
+    from aw_core import dirs  # deferred: keep this module importable without aw_core
+
+    marker = Path(dirs.get_data_dir("aw-qt")) / FIRST_RUN_MARKER
+    if marker.exists():
+        return
+    try:
+        enable()
+    except AutostartError as e:
+        logger.warning(
+            f"Could not enable autostart on first run (will retry next launch): {e}"
+        )
+        return
+    _write_text_atomic(marker, "start-at-login was enabled on first run\n")
+    logger.info("Enabled start-at-login on first run")

--- a/aw_qt/config.py
+++ b/aw_qt/config.py
@@ -13,9 +13,13 @@ logger = logging.getLogger(__name__)
 default_config = """
 [aw-qt]
 autostart_modules = ["aw-server", "aw-watcher-afk", "aw-watcher-window"]
+# Enable OS-level start-at-login on first launch (Research Edition builds
+# flip this to true; the user can still disable it from the tray afterwards).
+autostart_on_first_run = false
 
 [aw-qt-testing]
 autostart_modules = ["aw-server", "aw-watcher-afk", "aw-watcher-window"]
+autostart_on_first_run = false
 """.strip()
 
 
@@ -117,6 +121,9 @@ class AwQtSettings:
         config_section: Any = config[section_name]
 
         self.autostart_modules: List[str] = config_section["autostart_modules"]
+        self.autostart_on_first_run: bool = bool(
+            config_section.get("autostart_on_first_run", False)
+        )
         # Pass autostart_modules so port lookup targets the actual server type,
         # keeping the tray URL and the manager's probe endpoint consistent.
         self.port: int = _read_server_port(profile, self.autostart_modules)

--- a/aw_qt/main.py
+++ b/aw_qt/main.py
@@ -12,6 +12,7 @@ import click
 from PyQt6.QtCore import QLockFile
 from aw_core.log import setup_logging
 
+from . import autostart
 from .manager import Manager
 from .config import AwQtSettings
 from .profile import (
@@ -132,6 +133,9 @@ def main(
         if autostart_modules
         else config.autostart_modules
     )
+
+    if config.autostart_on_first_run and not testing:
+        autostart.ensure_enabled_on_first_run()
 
     manager = Manager(testing=testing)
     manager.autostart(_autostart_modules)

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -384,3 +384,49 @@ class TestCommand:
     def test_falls_back_to_module_invocation(self):
         with patch("shutil.which", return_value=None):
             assert autostart._command() == [autostart.sys.executable, "-m", "aw_qt"]
+
+
+class TestFirstRunEnable:
+    """Tests for ensure_enabled_on_first_run (Research Edition default-on)."""
+
+    @pytest.fixture
+    def data_dir(self, tmp_path):
+        with patch("aw_core.dirs.get_data_dir", return_value=str(tmp_path)):
+            yield tmp_path
+
+    def test_enables_and_writes_marker(self, data_dir):
+        with (
+            patch.object(autostart, "is_supported", return_value=True),
+            patch.object(autostart, "enable") as mock_enable,
+        ):
+            autostart.ensure_enabled_on_first_run()
+        mock_enable.assert_called_once()
+        assert (data_dir / autostart.FIRST_RUN_MARKER).exists()
+
+    def test_marker_prevents_reenable(self, data_dir):
+        (data_dir / autostart.FIRST_RUN_MARKER).write_text("done\n")
+        with (
+            patch.object(autostart, "is_supported", return_value=True),
+            patch.object(autostart, "enable") as mock_enable,
+        ):
+            autostart.ensure_enabled_on_first_run()
+        mock_enable.assert_not_called()
+
+    def test_failure_writes_no_marker_and_does_not_raise(self, data_dir):
+        with (
+            patch.object(autostart, "is_supported", return_value=True),
+            patch.object(
+                autostart, "enable", side_effect=autostart.AutostartError("boom")
+            ),
+        ):
+            autostart.ensure_enabled_on_first_run()
+        assert not (data_dir / autostart.FIRST_RUN_MARKER).exists()
+
+    def test_unsupported_platform_is_noop(self, data_dir):
+        with (
+            patch.object(autostart, "is_supported", return_value=False),
+            patch.object(autostart, "enable") as mock_enable,
+        ):
+            autostart.ensure_enabled_on_first_run()
+        mock_enable.assert_not_called()
+        assert not (data_dir / autostart.FIRST_RUN_MARKER).exists()


### PR DESCRIPTION
Adds an `autostart_on_first_run` config key (default `false`) to `[aw-qt]`. When true, aw-qt enables OS-level start-at-login (via the #127 machinery) on first launch and drops a marker file in the data dir so the user's later choice is always respected: disabling from the tray never gets overridden, and a failed enable writes no marker so it retries next launch. Skipped under `--testing` and on unsupported platforms.

Motivation: Research Edition study deployments (participants must survive reboots with zero setup; see the #127 motivation). The research CI build will flip this default to `true` via the existing config-patching step in the bundle repo — follow-up PR there.

Tests cover: enable+marker, marker-prevents-reenable, failure-no-marker-no-raise, unsupported-noop.